### PR TITLE
Pass the correct Session ID for serverside transcoding matching.

### DIFF
--- a/frontend/src/hooks/api/usePlaybackProgress.ts
+++ b/frontend/src/hooks/api/usePlaybackProgress.ts
@@ -7,13 +7,16 @@ interface PlaybackProgress {
     itemId: string;
     positionTicks: number;
     isPaused?: boolean;
+    playSessionId?: string;
+    volumeLevel?: number;
+    isMuted?: boolean;
 }
 
 export function useReportPlaybackProgress() {
     const { data: sessionId } = useCurrentSessionId();
 
     const { mutate: reportProgress, isPending } = useMutation({
-        mutationFn: async ({ itemId, positionTicks, isPaused }: PlaybackProgress) => {
+        mutationFn: async ({ itemId, positionTicks, isPaused, playSessionId, volumeLevel, isMuted }: PlaybackProgress) => {
             if (!itemId) throw new Error('Item ID is required');
             if (!sessionId) throw new Error('Session ID is required');
 
@@ -23,9 +26,12 @@ export function useReportPlaybackProgress() {
             await playstateApi.reportPlaybackProgress({
                 playbackProgressInfo: {
                     ItemId: itemId,
-                    SessionId: sessionId,
+                    // SessionId: sessionId,
+                    PlaySessionId: playSessionId,
                     PositionTicks: positionTicks,
                     IsPaused: isPaused,
+                    VolumeLevel: volumeLevel,
+                    IsMuted: isMuted,
                 },
             });
 

--- a/frontend/src/hooks/api/usePlaybackStart.ts
+++ b/frontend/src/hooks/api/usePlaybackStart.ts
@@ -6,13 +6,14 @@ import { useCurrentSessionId } from './useCurrentSessionId';
 interface StartPlaybackPayload {
     itemId: string;
     positionTicks?: number;
+    playSessionId?: string;
 }
 
 export function usePlaybackStart() {
     const { data: sessionId } = useCurrentSessionId();
 
     const { mutate: startPlayback, isPending } = useMutation({
-        mutationFn: async ({ itemId, positionTicks = 0 }: StartPlaybackPayload) => {
+        mutationFn: async ({ itemId, positionTicks = 0, playSessionId }: StartPlaybackPayload) => {
             if (!itemId) throw new Error('Item ID is required');
             if (!sessionId) throw new Error('Session ID is required');
 
@@ -22,7 +23,8 @@ export function usePlaybackStart() {
             await playstateApi.reportPlaybackStart({
                 playbackStartInfo: {
                     ItemId: itemId,
-                    SessionId: sessionId,
+                    // SessionId: sessionId,
+                    PlaySessionId: playSessionId,
                     PositionTicks: positionTicks,
                 },
             });

--- a/frontend/src/pages/Player/PlayerPage.tsx
+++ b/frontend/src/pages/Player/PlayerPage.tsx
@@ -180,7 +180,7 @@ const PlayerPage = () => {
         clearPlayback();
 
         // Report playback start
-        startPlayback({ itemId, positionTicks: startTicks });
+        startPlayback({ itemId, positionTicks: startTicks, playSessionId });
 
         const reportPlayerProgress = () => {
             if (!player || player.isDisposed?.()) return;
@@ -190,6 +190,8 @@ const PlayerPage = () => {
                 if (currentTime <= PLAYBACK_PROGRESS_REPORT_MIN_PLAYTIME_SECONDS) return;
                 const positionTicks = Math.floor(currentTime * 10000000); // Convert to ticks
                 const isPaused = player.paused();
+                const volumeLevel = player.volume() * 100;
+                const isMuted = player.muted();
 
                 lastPositionRef.current = positionTicks;
 
@@ -197,6 +199,9 @@ const PlayerPage = () => {
                     itemId,
                     positionTicks,
                     isPaused,
+                    playSessionId,
+                    volumeLevel,
+                    isMuted,
                 });
             } catch (error) {
                 console.error('Error reporting progress:', error);


### PR DESCRIPTION
- Fixed SessionId was passed instead of playSessionId
- Allows the Server to match it's transcode queue with the actual playSession
- isMuted and VolumeLevel now also get passed -> can pass more -> todo