### PR TITLE
Translate French (fr)

### DIFF
--- a/frontend/src/locales/fr/common.json
+++ b/frontend/src/locales/fr/common.json
@@ -1,4 +1,8 @@
 {
-  "previous": "Précédent",
-  "next": "Suivant"
+    "previous": "Précédent",
+    "next": "Suivant",
+    "stats_consent_title": "Aidez-nous à compter",
+    "stats_consent_message": "",
+    "stats_consent_reject": "",
+    "stats_consent_accept": ""
 }


### PR DESCRIPTION
Updates common for `fr` — 357/487 strings translated overall.

Submitted by @KartoffelChipss via the translation tool.