### PR TITLE
get more accurate sized logo

### DIFF
--- a/frontend/src/pages/Home/MediaBar.tsx
+++ b/frontend/src/pages/Home/MediaBar.tsx
@@ -141,8 +141,12 @@ const MediaBar = ({
                                                 src={getLogoUrl(
                                                     item.Id!,
                                                     {
-                                                        fillWidth: Math.ceil(672 * window.devicePixelRatio),
-                                                        fillHeight: Math.ceil(288 * window.devicePixelRatio),
+                                                        fillWidth: Math.ceil(
+                                                            672 * window.devicePixelRatio
+                                                        ),
+                                                        fillHeight: Math.ceil(
+                                                            288 * window.devicePixelRatio
+                                                        ),
                                                     },
                                                     item.ImageTags?.Logo
                                                 )}

--- a/frontend/src/pages/Home/MediaBar.tsx
+++ b/frontend/src/pages/Home/MediaBar.tsx
@@ -140,7 +140,10 @@ const MediaBar = ({
                                             <img
                                                 src={getLogoUrl(
                                                     item.Id!,
-                                                    { maxHeight: 400 },
+                                                    {
+                                                        fillWidth: Math.ceil(672 * window.devicePixelRatio),
+                                                        fillHeight: Math.ceil(288 * window.devicePixelRatio),
+                                                    },
                                                     item.ImageTags?.Logo
                                                 )}
                                                 alt={item.Name || 'Item Logo'}

--- a/frontend/src/utils/jellyfinUrls.ts
+++ b/frontend/src/utils/jellyfinUrls.ts
@@ -18,6 +18,8 @@ export interface ImageSize {
     height?: number;
     maxWidth?: number;
     maxHeight?: number;
+    fillWidth?: number;
+    fillHeight?: number;
 }
 
 export interface ItemImageOptions {
@@ -49,6 +51,8 @@ function buildItemImageUrl(
         if (size?.height) url.searchParams.append('height', size.height.toString());
         if (size?.maxWidth) url.searchParams.append('maxWidth', size.maxWidth.toString());
         if (size?.maxHeight) url.searchParams.append('maxHeight', size.maxHeight.toString());
+        if (size?.fillWidth) url.searchParams.append('fillWidth', size.fillWidth.toString());
+        if (size?.fillHeight) url.searchParams.append('fillHeight', size.fillHeight.toString());
 
         return url.toString();
     } catch {


### PR DESCRIPTION
Height
```css
.sm\:max-h-72
calc(var(--spacing) * 72)
.max-h-48
calc(var(--spacing) * 48)
```
-> larger size is 0.25*16 (standard value) * 72 * dpr (so high density will get more pixel)

Width
```
.max-w-2xl
var(--container-2xl)
```
-> 42 * 16 = 672

dpr, so high density gets an image size fitting for display.

fillWidth will not pass defined image size and keeps the ratio (similar to contain). (`max` is more like `cover` and will provide an image at least the defined size)