### PR TITLE
fix(player): remove redundant time display next to play/pause button

### DIFF
--- a/frontend/src/pages/Player/PlayerControls.tsx
+++ b/frontend/src/pages/Player/PlayerControls.tsx
@@ -793,14 +793,11 @@ const PlayerControls = ({
                                 </Link>
                             </Button>
                         )}
-                        {isLive ? (
+                        {/* Live indicator only: non-live time is redundant (already shown below progress bar) */}
+                        {isLive && (
                             <div className="flex items-center gap-1.5 text-sm ml-2">
                                 <Dot className="text-red-500 -mx-1" size={32} />
                                 {t('live')}
-                            </div>
-                        ) : (
-                            <div className="text-sm ml-2">
-                                {formatPlayTime(clampedCurrentTime)} / {formatPlayTime(duration)}
                             </div>
                         )}
                     </div>


### PR DESCRIPTION
The current time and duration are already displayed at both ends of the progress bar. Showing them again next to the play/pause button is redundant. This change removes the duplicate, keeping only the LIVE indicator for live streams.
## Summary

Removes the redundant current time / duration display that appears next to the play/pause button in the player controls.

## Rationale

The current time and total duration are **already displayed at both ends of the progress bar** (below it). Showing them again next to the play/pause button is redundant and adds visual clutter to the control bar.

## Changes

- Replaced the `isLive ? (...) : (<time display>)` ternary with `isLive && (...)` 
- For non-live content, the time is no longer shown next to the button (progress bar already shows it)
- The **LIVE indicator** (red dot + "Live" text) is preserved for live streams