### PR TITLE
fix(player): move time display below progress bar, remove duplicate

### DIFF
--- a/frontend/src/pages/Player/PlayerControls.tsx
+++ b/frontend/src/pages/Player/PlayerControls.tsx
@@ -756,6 +756,14 @@ const PlayerControls = ({
                     </div>
                 )}
 
+                {/* Time display below progress bar: current time on the left, duration on the right */}
+                {!isLive && (
+                    <div className="flex justify-between items-center text-xs text-gray-400 mt-1.5 px-0.5 font-medium select-none pointer-events-none">
+                        <span className="tabular-nums">{formatPlayTime(clampedCurrentTime)}</span>
+                        <span className="tabular-nums">{formatPlayTime(duration)}</span>
+                    </div>
+                )}
+
                 {/* Controls */}
                 <div className="flex items-center justify-between text-white gap-4">
                     <div className="flex items-center gap-2">
@@ -793,14 +801,11 @@ const PlayerControls = ({
                                 </Link>
                             </Button>
                         )}
-                        {isLive ? (
+                        {/* Live indicator only: non-live time is redundant (already shown below progress bar) */}
+                        {isLive && (
                             <div className="flex items-center gap-1.5 text-sm ml-2">
                                 <Dot className="text-red-500 -mx-1" size={32} />
                                 {t('live')}
-                            </div>
-                        ) : (
-                            <div className="text-sm ml-2">
-                                {formatPlayTime(clampedCurrentTime)} / {formatPlayTime(duration)}
                             </div>
                         )}
                     </div>


### PR DESCRIPTION
The current time and duration were shown next to the play/pause button, which is visually cluttered. This change moves the time display to below the progress bar (current time on the left, duration on the right), similar to most modern video players. The LIVE indicator is preserved for live streams.
## Summary

Moves the current time / duration display from next to the play/pause button to below the progress bar (current time on the left, duration on the right).

## Rationale

Having the time display next to the play/pause button is visually cluttered. Most modern video players (YouTube, Netflix, etc.) display the time at both ends of the progress bar instead.

## Changes

- **Removed** the `currentTime / duration` text next to the play/pause button
- **Added** time display below the progress bar (left: current time, right: duration), only for non-live content
- The **LIVE indicator** (red dot + "Live" text) is preserved for live streams