### PR TITLE
feat(player): playback controls and mobile fullscreen improvements

### DIFF
--- a/.github/PR_detail_page_back_button_cover_play.md
+++ b/.github/PR_detail_page_back_button_cover_play.md
@@ -1,0 +1,74 @@
+# Detail Page: Back Button, Cover Play Button & Cover Size Optimization
+
+## Summary
+
+This PR introduces three UX improvements to the item detail pages (Movie, Episode, Series, Season, BoxSet):
+
+1. **Back button** — A floating back button on the cover that intelligently navigates the user back
+2. **Cover play button** — Movie & episode covers are now clickable to start playback directly, with a hover play overlay
+3. **Cover size optimization** — Cover aspect ratio is dynamically calculated from the image's natural dimensions instead of a fixed 2:3 ratio
+
+---
+
+## Changes
+
+### 1. Back Button (`ItemBackButton`)
+
+- **New component**: `frontend/src/pages/Item/ItemBackButton.tsx`
+- A small floating button (top-left of the cover) with backdrop blur and fade-in animation
+- **Smart navigation logic** in `ItemPage.tsx`:
+  - First attempts `navigate(-1)` (browser history back) if history exists
+  - Falls back to type-aware parent navigation:
+    - `Episode` → Season → Series → Home
+    - `Season` → Series → Parent → Home
+    - `Movie` / `Series` / `BoxSet` → Parent library → Library page
+- `stopPropagation` + `preventDefault` ensures the button click doesn't trigger the cover's play link
+
+### 2. Cover Play Button (Movie & Episode only)
+
+- The poster/thumbnail is wrapped in a `<Link to="/play/{itemId}">` making the entire cover clickable
+- On hover (desktop), a semi-transparent circular play button fades in at the center
+- On mobile, the play overlay is always visible (`opacity-100`)
+- Applied to `MoviePage.tsx` and `EpisodePage.tsx`
+
+### 3. Cover Size Optimization (all detail pages)
+
+- Replaced the fixed `aspect-2/3` ratio with a dynamic `aspectRatio` style
+- Reads the image's `naturalWidth` / `naturalHeight` on load and calculates the real ratio
+- Falls back to `item.PrimaryImageAspectRatio`, then `2/3` as a sensible default
+- Added `prevItemId` tracking to reset the ratio when navigating between items
+- Enlarged responsive width classes (`sm:max-w-[24rem]` → `xl:max-w-[36rem]`) to better utilize large screens
+- Applied to `MoviePage`, `EpisodePage`, `SeriesPage`, `SeasonPage`, `BoxSetPage`
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `ItemBackButton.tsx` | **New** — Back button component |
+| `ItemPage.tsx` | `handleBack` logic + `onBack` prop passed to child pages |
+| `MoviePage.tsx` | Back button + cover play button + cover size optimization |
+| `EpisodePage.tsx` | Back button + cover play button |
+| `SeriesPage.tsx` | Back button + cover size optimization |
+| `SeasonPage.tsx` | Back button + cover size optimization |
+| `BoxSetPage.tsx` | Back button + cover size optimization |
+
+**7 files changed, +310 / -127 lines**
+
+---
+
+## Screenshots
+
+<!-- TODO: Add before/after screenshots here -->
+
+---
+
+## Testing
+
+- [ ] Enter a Movie detail page → cover left-top shows back button, clicking it returns to library
+- [ ] Enter an Episode detail page → cover is clickable, hover shows play button
+- [ ] Enter a Series/Season/BoxSet detail page → back button works, cover ratio adapts to non-standard posters
+- [ ] Navigate between items → aspect ratio resets correctly (no stale ratio from previous item)
+- [ ] Mobile: play overlay is always visible on cover
+- [ ] Back button click does not trigger cover play navigation

--- a/frontend/src/pages/Player/PlayerControls.tsx
+++ b/frontend/src/pages/Player/PlayerControls.tsx
@@ -124,14 +124,18 @@ const PlayerControls = ({
 }: PlayerControlsProps) => {
     const { t } = useTranslation('player');
     const [isPlaying, setIsPlaying] = useState(false);
+    const [playbackRate, setPlaybackRate] = useState(1);
     const [currentTime, setCurrentTime] = useState(0);
-    const [duration, setDuration] = useState(0);
+    const [duration, setDuration] = useState(() => {
+        return item.RunTimeTicks ? ticksToSeconds(item.RunTimeTicks) : 0;
+    });
     const [bufferedTime, setBufferedTime] = useState(0);
     const [volume, setVolume] = useState(() => {
         const saved = localStorage.getItem('playerVolume');
         return saved ? parseFloat(saved) : 1;
     });
     const [isMuted, setIsMuted] = useState(false);
+    const [showVolumeBar, setShowVolumeBar] = useState(false);
     const [hoverTime, setHoverTime] = useState<number | null>(null);
     const [hoverPosition, setHoverPosition] = useState<number>(0);
     const [showControls, setShowControls] = useState(true);
@@ -193,13 +197,17 @@ const PlayerControls = ({
     const markItemAsCompleted = useCallback(
         (itemId: string | undefined) => {
             if (!itemId) return;
+            const playerDuration = player && !player.isDisposed?.() ? player.duration() : 0;
+            const finalTicks = playerDuration && playerDuration > 0 && playerDuration !== Infinity && !isNaN(playerDuration)
+                ? Math.floor(playerDuration * 10000000)
+                : (item.RunTimeTicks || 0);
             reportProgress({
                 itemId,
-                positionTicks: item.RunTimeTicks || 0,
+                positionTicks: finalTicks,
                 isPaused: true,
             });
         },
-        [item.RunTimeTicks, reportProgress]
+        [item.RunTimeTicks, player, reportProgress]
     );
 
     useEffect(() => {
@@ -221,7 +229,18 @@ const PlayerControls = ({
 
         const updatePlayState = () => setIsPlaying(!player.paused());
         const updateTime = () => setCurrentTime(player.currentTime() || 0);
-        const updateDuration = () => setDuration(player.duration() || 0);
+        const updateDuration = () => {
+            const playerDuration = player.duration();
+            if (playerDuration && playerDuration > 0 && playerDuration !== Infinity && !isNaN(playerDuration)) {
+                setDuration(playerDuration);
+            } else if (item.RunTimeTicks) {
+                setDuration(ticksToSeconds(item.RunTimeTicks));
+            } else {
+                setDuration(playerDuration || 0);
+            }
+            // Ensure playback rate is synced after video load/stream switch
+            player.playbackRate(playbackRate);
+        };
         const updateMuted = () => setIsMuted(player.muted() || false);
         const updateBuffered = () => {
             const buffered = player.buffered();
@@ -234,6 +253,10 @@ const PlayerControls = ({
             if (!nextItem) return;
             markItemAsCompleted(item.Id);
             navigate(buildPlayerUrl(nextItem.Id!, backUrl ?? undefined));
+        };
+
+        const handleRateChange = () => {
+            setPlaybackRate(player.playbackRate() || 1);
         };
 
         // PiP event listeners
@@ -250,9 +273,11 @@ const PlayerControls = ({
         player.on('timeupdate', updateTime);
         player.on('timeupdate', updateBuffered);
         player.on('loadedmetadata', updateDuration);
+        player.on('durationchange', updateDuration);
         player.on('progress', updateBuffered);
         player.on('volumechange', updateMuted);
         player.on('ended', handleEnded);
+        player.on('ratechange', handleRateChange);
 
         return () => {
             player.off('play', updatePlayState);
@@ -260,9 +285,11 @@ const PlayerControls = ({
             player.off('timeupdate', updateTime);
             player.off('timeupdate', updateBuffered);
             player.off('loadedmetadata', updateDuration);
+            player.off('durationchange', updateDuration);
             player.off('progress', updateBuffered);
             player.off('volumechange', updateMuted);
             player.off('ended', handleEnded);
+            player.off('ratechange', handleRateChange);
 
             if (videoEl) {
                 videoEl.removeEventListener('enterpictureinpicture', handleEnterPiP);
@@ -275,9 +302,11 @@ const PlayerControls = ({
         nextItem,
         dismissedNextItemPrompt,
         item.Id,
+        item.RunTimeTicks,
         navigate,
         markItemAsCompleted,
         backUrl,
+        playbackRate,
     ]);
 
     const togglePlay = useCallback(() => {
@@ -755,6 +784,11 @@ const PlayerControls = ({
                             })()}
                     </div>
                 )}
+                {/* Time display below progress bar: current time on the left, duration on the right */}
+                <div className="flex justify-between items-center text-xs text-gray-400 mt-1.5 px-0.5 font-medium select-none pointer-events-none">
+                    <span className="tabular-nums">{formatPlayTime(clampedCurrentTime)}</span>
+                    <span className="tabular-nums">{formatPlayTime(duration)}</span>
+                </div>
 
                 {/* Controls */}
                 <div className="flex items-center justify-between text-white gap-4">
@@ -881,22 +915,81 @@ const PlayerControls = ({
                                 </DropdownMenuContent>
                             </DropdownMenu>
                         )}
-                        <Button
-                            variant={'ghost'}
-                            size={'icon-lg'}
-                            onClick={toggleMute}
-                            className="cursor-pointer"
+                        {/* Volume control: hover/touch to slide out the volume bar; click icon to toggle mute when bar is visible */}
+                        <div
+                            className="flex items-center h-10"
+                            onMouseEnter={() => setShowVolumeBar(true)}
+                            onMouseLeave={() => setShowVolumeBar(false)}
                         >
-                            {isMuted ? <VolumeX /> : <Volume2 />}
-                        </Button>
-                        <Slider
-                            min={0}
-                            max={1}
-                            step={0.1}
-                            value={isMuted ? [0] : [volume]}
-                            onValueChange={handleVolumeChange}
-                            className="w-25 cursor-pointer mr-2"
-                        />
+                            <Button
+                                variant={'ghost'}
+                                size={'icon-lg'}
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    if (showVolumeBar) {
+                                        toggleMute();
+                                    } else {
+                                        setShowVolumeBar(true);
+                                    }
+                                }}
+                                className="cursor-pointer"
+                            >
+                                {isMuted ? <VolumeX /> : <Volume2 />}
+                            </Button>
+                            <div
+                                className={`flex items-center transition-all duration-300 ease-in-out ${
+                                    showVolumeBar
+                                        ? 'w-24 opacity-100 ml-2'
+                                        : 'w-0 opacity-0 overflow-hidden pointer-events-none'
+                                }`}
+                            >
+                                <Slider
+                                    min={0}
+                                    max={1}
+                                    step={0.1}
+                                    value={isMuted ? [0] : [volume]}
+                                    onValueChange={handleVolumeChange}
+                                    className="w-24 cursor-pointer mr-2"
+                                />
+                            </div>
+                        </div>
+                        {/* Playback speed control */}
+                        <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                                <Button
+                                    variant={'ghost'}
+                                    size={'icon-lg'}
+                                    className="cursor-pointer text-sm font-semibold select-none"
+                                    title="Playback speed"
+                                >
+                                    <span className="text-[13px]">{playbackRate}x</span>
+                                </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent container={container} className="w-40 z-50">
+                                <DropdownMenuLabel>Playback Speed</DropdownMenuLabel>
+                                <DropdownMenuSeparator />
+                                <DropdownMenuRadioGroup
+                                    value={playbackRate.toString()}
+                                    onValueChange={(val) => setPlaybackRate(parseFloat(val))}
+                                >
+                                    <DropdownMenuRadioItem value="0.5">0.5x</DropdownMenuRadioItem>
+                                    <DropdownMenuRadioItem value="0.75">
+                                        0.75x
+                                    </DropdownMenuRadioItem>
+                                    <DropdownMenuRadioItem value="1">
+                                        1.0x (Normal)
+                                    </DropdownMenuRadioItem>
+                                    <DropdownMenuRadioItem value="1.25">
+                                        1.25x
+                                    </DropdownMenuRadioItem>
+                                    <DropdownMenuRadioItem value="1.5">1.5x</DropdownMenuRadioItem>
+                                    <DropdownMenuRadioItem value="1.75">
+                                        1.75x
+                                    </DropdownMenuRadioItem>
+                                    <DropdownMenuRadioItem value="2">2.0x</DropdownMenuRadioItem>
+                                </DropdownMenuRadioGroup>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
                         {document.pictureInPictureEnabled && (
                             <Button
                                 variant={'ghost'}

--- a/frontend/src/pages/Player/PlayerControls.tsx
+++ b/frontend/src/pages/Player/PlayerControls.tsx
@@ -198,9 +198,13 @@ const PlayerControls = ({
         (itemId: string | undefined) => {
             if (!itemId) return;
             const playerDuration = player && !player.isDisposed?.() ? player.duration() : 0;
-            const finalTicks = playerDuration && playerDuration > 0 && playerDuration !== Infinity && !isNaN(playerDuration)
-                ? Math.floor(playerDuration * 10000000)
-                : (item.RunTimeTicks || 0);
+            const finalTicks =
+                playerDuration &&
+                playerDuration > 0 &&
+                playerDuration !== Infinity &&
+                !isNaN(playerDuration)
+                    ? Math.floor(playerDuration * 10000000)
+                    : item.RunTimeTicks || 0;
             reportProgress({
                 itemId,
                 positionTicks: finalTicks,
@@ -231,7 +235,12 @@ const PlayerControls = ({
         const updateTime = () => setCurrentTime(player.currentTime() || 0);
         const updateDuration = () => {
             const playerDuration = player.duration();
-            if (playerDuration && playerDuration > 0 && playerDuration !== Infinity && !isNaN(playerDuration)) {
+            if (
+                playerDuration &&
+                playerDuration > 0 &&
+                playerDuration !== Infinity &&
+                !isNaN(playerDuration)
+            ) {
                 setDuration(playerDuration);
             } else if (item.RunTimeTicks) {
                 setDuration(ticksToSeconds(item.RunTimeTicks));

--- a/frontend/src/pages/Player/PlayerPage.tsx
+++ b/frontend/src/pages/Player/PlayerPage.tsx
@@ -145,7 +145,6 @@ const PlayerPage = () => {
             }
         };
 
-
         const handleFullscreenChange = () => {
             const isFS = !!(
                 document.fullscreenElement ||
@@ -159,7 +158,10 @@ const PlayerPage = () => {
                 // Try Screen Orientation API to lock landscape; fall back to CSS rotation
                 if (screen.orientation && (screen.orientation as any).lock) {
                     (screen.orientation as any).lock('landscape').catch((err: any) => {
-                        console.warn('Could not lock screen orientation, falling back to CSS rotation:', err);
+                        console.warn(
+                            'Could not lock screen orientation, falling back to CSS rotation:',
+                            err
+                        );
                         checkOrientation();
                     });
                 } else {

--- a/frontend/src/pages/Player/PlayerPage.tsx
+++ b/frontend/src/pages/Player/PlayerPage.tsx
@@ -83,6 +83,7 @@ const PlayerPage = () => {
     const [subtitleTrackIndex, setSubtitleTrackIndex] = useState<number | null>(
         resolvedSubtitleTrackIndex
     );
+    const [shouldRotate, setShouldRotate] = useState(false);
     const containerRef = useRef<HTMLDivElement>(null);
     const progressReportingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
     const lastPositionRef = useRef<number>(0);
@@ -130,13 +131,68 @@ const PlayerPage = () => {
     }, [playbackInfo?.liveStreamId]);
 
     useEffect(() => {
+        const checkOrientation = () => {
+            const isFS = !!(
+                document.fullscreenElement ||
+                (document as any).webkitFullscreenElement ||
+                (document as any).mozFullscreenElement ||
+                (document as any).msFullscreenElement
+            );
+            if (isFS && window.innerHeight > window.innerWidth) {
+                setShouldRotate(true);
+            } else {
+                setShouldRotate(false);
+            }
+        };
+
+
         const handleFullscreenChange = () => {
-            setIsFullscreen(!!document.fullscreenElement);
+            const isFS = !!(
+                document.fullscreenElement ||
+                (document as any).webkitFullscreenElement ||
+                (document as any).mozFullscreenElement ||
+                (document as any).msFullscreenElement
+            );
+            setIsFullscreen(isFS);
+
+            if (isFS) {
+                // Try Screen Orientation API to lock landscape; fall back to CSS rotation
+                if (screen.orientation && (screen.orientation as any).lock) {
+                    (screen.orientation as any).lock('landscape').catch((err: any) => {
+                        console.warn('Could not lock screen orientation, falling back to CSS rotation:', err);
+                        checkOrientation();
+                    });
+                } else {
+                    checkOrientation();
+                }
+            } else {
+                setShouldRotate(false);
+                if (screen.orientation && (screen.orientation as any).unlock) {
+                    try {
+                        (screen.orientation as any).unlock();
+                    } catch (err: any) {
+                        console.warn('Could not unlock screen orientation:', err);
+                    }
+                }
+            }
         };
 
         document.addEventListener('fullscreenchange', handleFullscreenChange);
+        document.addEventListener('webkitfullscreenchange', handleFullscreenChange);
+        document.addEventListener('mozfullscreenchange', handleFullscreenChange);
+        document.addEventListener('MSFullscreenChange', handleFullscreenChange);
+
+        window.addEventListener('resize', checkOrientation);
+        window.addEventListener('orientationchange', checkOrientation);
+
         return () => {
             document.removeEventListener('fullscreenchange', handleFullscreenChange);
+            document.removeEventListener('webkitfullscreenchange', handleFullscreenChange);
+            document.removeEventListener('mozfullscreenchange', handleFullscreenChange);
+            document.removeEventListener('MSFullscreenChange', handleFullscreenChange);
+
+            window.removeEventListener('resize', checkOrientation);
+            window.removeEventListener('orientationchange', checkOrientation);
         };
     }, []);
 
@@ -344,7 +400,23 @@ const PlayerPage = () => {
     }
 
     return (
-        <div ref={containerRef} className="relative w-full h-screen bg-black flex overflow-hidden">
+        <div
+            ref={containerRef}
+            className={`bg-black flex overflow-hidden ${
+                shouldRotate ? 'fixed inset-0 z-[9999]' : 'relative w-full h-screen'
+            }`}
+            style={
+                shouldRotate
+                    ? {
+                          width: '100vh',
+                          height: '100vw',
+                          top: '50%',
+                          left: '50%',
+                          transform: 'translate(-50%, -50%) rotate(90deg)',
+                      }
+                    : undefined
+            }
+        >
             <VideoPlayer
                 key={itemId}
                 src={streamResult.url}

--- a/frontend/src/pages/Player/VideoPlayer.tsx
+++ b/frontend/src/pages/Player/VideoPlayer.tsx
@@ -47,7 +47,7 @@ const VideoPlayer = ({
             responsive: false,
             fluid: false,
             html5: {
-                nativeControlsForTouch: true,
+                nativeControlsForTouch: false,
                 hls: { overrideNative: true },
                 nativeTextTracks: false, // Force video.js to render text tracks
             },
@@ -164,6 +164,8 @@ const VideoPlayer = ({
                 ref={videoRef}
                 className="video-js vjs-default-skin"
                 data-testid="video-player"
+                playsInline
+                webkit-playsinline="true"
                 style={{ maxWidth: '100%', maxHeight: '100%', width: '100%', height: '100%' }}
             >
                 <track kind="captions" srcLang="en" label="English" />


### PR DESCRIPTION
Player Controls:

- Move time display below progress bar, remove duplicate next to play button

- Add playback speed control (0.5x to 2.0x)

- Volume control: hover/touch to slide out volume bar, click to toggle mute

- Duration initialization with RunTimeTicks fallback for smoother UX

- Improved markItemAsCompleted to use actual player duration

Mobile & Fullscreen:

- Auto-rotate to landscape on fullscreen for mobile devices

- Cross-browser fullscreen API support (webkit/moz/MS)

- Screen Orientation API lock with CSS rotation fallback

- Add playsInline and webkit-playsinline for iOS support

- Disable native touch controls in favor of custom controls