### PR TITLE
feat: add back button, cover play button, and cover size optimization…

### DIFF
--- a/frontend/src/pages/Item/BoxSetPage.tsx
+++ b/frontend/src/pages/Item/BoxSetPage.tsx
@@ -14,18 +14,30 @@ import { ImageOff } from 'lucide-react';
 import { getLogoUrl } from '@/utils/jellyfinUrls';
 import Overview from './Overview';
 import ItemMetadataBadges from './ItemMetadataBadges';
+import ItemBackButton from './ItemBackButton';
 
 interface BoxSetPageProps {
     item: BaseItemDto;
     config: AppConfig;
+    onBack?: () => void;
 }
 
-const BoxSetPage = ({ item, config }: BoxSetPageProps) => {
+const BoxSetPage = ({ item, config, onBack }: BoxSetPageProps) => {
     const { t } = useTranslation('item');
     const [primaryImageError, setPrimaryImageError] = useState(false);
     const { data: boxSetItems } = useBoxSetItems(item.Id || '');
     const [isPosterLoaded, setIsPosterLoaded] = useState(false);
     const [failedLogo, setFailedLogo] = useState(false);
+    const [customAspectRatio, setCustomAspectRatio] = useState<number | null>(null);
+    const [prevItemId, setPrevItemId] = useState<string | undefined>(item.Id);
+
+    // 切换 item 时重置自定义宽高比，避免上一张图的 ratio 残留
+    if (item.Id !== prevItemId) {
+        setPrevItemId(item.Id);
+        setCustomAspectRatio(null);
+    }
+
+    const currentAspectRatio = customAspectRatio ?? item.PrimaryImageAspectRatio ?? (2 / 3);
 
     return (
         <BaseMediaPage
@@ -35,36 +47,45 @@ const BoxSetPage = ({ item, config }: BoxSetPageProps) => {
             topPadding={false}
         >
             <div className="pt-24 sm:pt-32 pb-12 mx-auto w-full flex flex-col gap-12">
-                <div className="flex flex-col lg:flex-row gap-8 lg:gap-12 items-start relative z-10 w-full">
+                <div className="flex flex-col lg:flex-row gap-8 lg:gap-12 items-stretch lg:items-start relative z-10 w-full">
                     {/* Poster */}
-                    <div className="w-48 sm:w-64 md:w-72 lg:w-80 shrink-0 mx-auto lg:mx-0">
-                        <div className="relative aspect-2/3 w-full rounded-xl overflow-hidden shadow-2xl shadow-black/85 border border-white/10 bg-muted flex items-center justify-center">
-                            {!primaryImageError ? (
-                                <>
-                                    <Skeleton className="absolute inset-0 w-full h-full rounded-xl" />
-
-                                    <img
-                                        src={getPrimaryImageUrl(
-                                            item.Id || '',
-                                            { width: 640, height: 960 },
-                                            item.ImageTags?.Primary
-                                        )}
-                                        alt={item.Name + ' Primary'}
-                                        className={[
-                                            'object-cover rounded-xl w-full h-full relative z-10',
-                                            'transition-[filter,opacity] duration-700 ease-out',
-                                            isPosterLoaded
-                                                ? 'blur-0 opacity-100'
-                                                : 'blur-md opacity-0',
-                                        ].join(' ')}
-                                        onLoad={() => setIsPosterLoaded(true)}
-                                        onError={() => setPrimaryImageError(true)}
-                                    />
-                                </>
-                            ) : (
+                    <div
+                        className="relative -mx-4 sm:mx-auto lg:mx-0 w-[calc(100%+2rem)] sm:w-full sm:max-w-[24rem] lg:max-w-[30rem] xl:max-w-[36rem] shadow-lg overflow-hidden group shrink-0 bg-black/30"
+                        style={{ aspectRatio: currentAspectRatio }}
+                    >
+                        {!primaryImageError ? (
+                            <>
+                                <Skeleton className="absolute inset-0 w-full h-full" />
+                                <img
+                                    src={getPrimaryImageUrl(
+                                        item.Id || '',
+                                        undefined,
+                                        item.ImageTags?.Primary
+                                    )}
+                                    alt={item.Name + ' Primary'}
+                                    className={[
+                                        'object-cover w-full h-full relative z-10 bg-black/20',
+                                        'transition-[filter,opacity] duration-700 ease-out',
+                                        isPosterLoaded
+                                            ? 'blur-0 opacity-100'
+                                            : 'blur-md opacity-0',
+                                    ].join(' ')}
+                                    onLoad={(e) => {
+                                        setIsPosterLoaded(true);
+                                        const img = e.currentTarget;
+                                        if (img.naturalWidth && img.naturalHeight) {
+                                            setCustomAspectRatio(img.naturalWidth / img.naturalHeight);
+                                        }
+                                    }}
+                                    onError={() => setPrimaryImageError(true)}
+                                />
+                            </>
+                        ) : (
+                            <div className="w-full h-full flex items-center justify-center bg-muted">
                                 <ImageOff className="text-muted-foreground w-12 h-12" />
-                            )}
-                        </div>
+                            </div>
+                        )}
+                        {onBack && <ItemBackButton onClick={onBack} />}
                     </div>
 
                     {/* Details */}

--- a/frontend/src/pages/Item/EpisodePage.tsx
+++ b/frontend/src/pages/Item/EpisodePage.tsx
@@ -1,7 +1,7 @@
 import type { AppConfig } from '@/hooks/api/useConfig';
 import type { BaseItemDto } from '@jellyfin/sdk/lib/generated-client/models';
 import BaseMediaPage from './BaseMediaPage';
-import { Dot, ImageOff } from 'lucide-react';
+import { Dot, ImageOff, Play } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { getPrimaryImageUrl, getThumbUrl } from '@/utils/jellyfinUrls';
 import DetailBadges from './DetailBadges';
@@ -27,13 +27,15 @@ import SourcePickerButton from '@/components/SourcePickerButton';
 import { Link } from 'react-router';
 import { Skeleton } from '@/components/ui/skeleton';
 import Overview from './Overview';
+import ItemBackButton from './ItemBackButton';
 
 interface EpisodePageProps {
     item: BaseItemDto;
     config: AppConfig;
+    onBack?: () => void;
 }
 
-const EpisodePage = ({ item, config }: EpisodePageProps) => {
+const EpisodePage = ({ item, config, onBack }: EpisodePageProps) => {
     const { t } = useTranslation('item');
     const [imageError, setImageError] = useState<boolean>(false);
     const [isImageLoaded, setIsImageLoaded] = useState<boolean>(false);
@@ -65,11 +67,11 @@ const EpisodePage = ({ item, config }: EpisodePageProps) => {
                 <div className="flex flex-col lg:flex-row gap-8 lg:gap-12 items-start relative z-10 w-full">
                     {/* Left Column (Thumbnail) */}
                     <div className="w-full sm:w-72 md:w-96 lg:w-120 shrink-0 mx-auto lg:mx-0">
-                        <div className="relative w-full aspect-video rounded-xl overflow-hidden shadow-2xl shadow-black/85 border border-white/10 bg-muted flex items-center justify-center">
+                        <div className="relative w-full aspect-video rounded-xl overflow-hidden shadow-2xl shadow-black/85 border border-white/10 bg-muted flex items-center justify-center group">
                             {imageError ? (
                                 <ImageOff className="w-12 h-12 text-muted-foreground" />
                             ) : (
-                                <>
+                                <Link to={`/play/${item.Id}`} className="block w-full h-full relative cursor-pointer z-10">
                                     <Skeleton className="absolute inset-0 w-full h-full rounded-xl" />
                                     <img
                                         src={
@@ -96,7 +98,13 @@ const EpisodePage = ({ item, config }: EpisodePageProps) => {
                                         onLoad={() => setIsImageLoaded(true)}
                                         onError={() => setImageError(true)}
                                     />
-                                </>
+                                    {/* 半透明大播放按钮 */}
+                                    <div className="absolute inset-0 bg-black/15 md:bg-black/25 opacity-100 md:opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center z-20">
+                                        <div className="h-16 w-16 bg-white/25 md:bg-white/20 hover:bg-white/35 backdrop-blur-md border border-white/30 rounded-full flex items-center justify-center hover:scale-110 active:scale-95 transition-all duration-300 shadow-xl">
+                                            <Play className="h-8 w-8 text-white fill-white ml-1" />
+                                        </div>
+                                    </div>
+                                </Link>
                             )}
                             {progress > 0 && (
                                 <div className="absolute bottom-0 left-0 right-0 h-1 bg-gray-700 z-20">
@@ -106,6 +114,7 @@ const EpisodePage = ({ item, config }: EpisodePageProps) => {
                                     />
                                 </div>
                             )}
+                            {onBack && <ItemBackButton onClick={onBack} />}
                         </div>
                     </div>
 

--- a/frontend/src/pages/Item/ItemBackButton.tsx
+++ b/frontend/src/pages/Item/ItemBackButton.tsx
@@ -1,0 +1,31 @@
+import { ArrowLeft } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface ItemBackButtonProps {
+    onClick: () => void;
+}
+
+/**
+ * 详情页返回按钮 — 浮于封面左上角，点击后执行智能返回导航。
+ * stopPropagation + preventDefault 确保点击不会触发封面本身的播放跳转。
+ */
+const ItemBackButton = ({ onClick }: ItemBackButtonProps) => {
+    return (
+        <div className="absolute top-2 left-2 z-40">
+            <Button
+                variant="outline"
+                size="icon"
+                className="rounded-full h-9 w-9 bg-background/40 backdrop-blur-md border border-border/40 hover:bg-background/80 hover:scale-105 active:scale-95 transition-all shadow-md cursor-pointer flex items-center justify-center animate-fade-in"
+                onClick={(e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    onClick();
+                }}
+            >
+                <ArrowLeft className="h-4 w-4" />
+            </Button>
+        </div>
+    );
+};
+
+export default ItemBackButton;

--- a/frontend/src/pages/Item/ItemPage.tsx
+++ b/frontend/src/pages/Item/ItemPage.tsx
@@ -1,4 +1,4 @@
-import { Navigate, useParams } from 'react-router';
+import { Navigate, useParams, useNavigate } from 'react-router';
 import Page from '../Page';
 import { useItem } from '@/hooks/api/useItem';
 import MoviePage from './MoviePage';
@@ -99,9 +99,59 @@ const ItemPage = () => {
     const { t } = useTranslation('item');
     const params = useParams<{ itemId: string }>();
     const itemId = params.itemId;
+    const navigate = useNavigate();
 
     const { config, loading: configLoading } = useConfig();
     const { data: item, isLoading, error } = useItem(itemId, true, getUserId() || undefined);
+
+    /**
+     * 智能返回导航：优先使用浏览器历史后退；
+     * 无历史时根据 item 类型回退到对应的上级页面（剧集→季→剧集→库等）。
+     */
+    const handleBack = () => {
+        if (window.history.state && window.history.state.idx > 0) {
+            navigate(-1);
+            return;
+        }
+
+        if (!item) {
+            navigate(-1);
+            return;
+        }
+
+        switch (item.Type) {
+            case 'Episode':
+                if (item.ParentId) {
+                    navigate(`/item/${item.ParentId}`);
+                } else if (item.SeriesId) {
+                    navigate(`/item/${item.SeriesId}`);
+                } else {
+                    navigate('/');
+                }
+                break;
+            case 'Season':
+                if (item.SeriesId) {
+                    navigate(`/item/${item.SeriesId}`);
+                } else if (item.ParentId) {
+                    navigate(`/item/${item.ParentId}`);
+                } else {
+                    navigate('/');
+                }
+                break;
+            case 'Movie':
+            case 'Series':
+            case 'BoxSet':
+                if (item.ParentId) {
+                    navigate(`/library?library=${item.ParentId}`);
+                } else {
+                    navigate('/library');
+                }
+                break;
+            default:
+                navigate(-1);
+                break;
+        }
+    };
 
     const redirectPath =
         item?.Type && REDIRECT_ITEM_TYPES[item.Type]
@@ -114,7 +164,7 @@ const ItemPage = () => {
     return (
         <Page
             title={item ? `${item.Name}` : isLoading ? t('loading') : t('item_not_found')}
-            className="flex-1 flex flex-col"
+            className="flex-1 flex flex-col relative"
             overlayHeader={isFullPageItem}
             pagePadding={!isFullPageItem}
         >
@@ -124,15 +174,15 @@ const ItemPage = () => {
                 (() => {
                     switch (item.Type) {
                         case 'Movie':
-                            return <MoviePage item={item} config={config} />;
+                            return <MoviePage item={item} config={config} onBack={handleBack} />;
                         case 'Series':
-                            return <SeriesPage item={item} config={config} />;
+                            return <SeriesPage item={item} config={config} onBack={handleBack} />;
                         case 'Episode':
-                            return <EpisodePage item={item} config={config} />;
+                            return <EpisodePage item={item} config={config} onBack={handleBack} />;
                         case 'Season':
-                            return <SeasonPage item={item} config={config} />;
+                            return <SeasonPage item={item} config={config} onBack={handleBack} />;
                         case 'BoxSet':
-                            return <BoxSetPage item={item} config={config} />;
+                            return <BoxSetPage item={item} config={config} onBack={handleBack} />;
                         case 'Studio':
                             return <StudioPage item={item} />;
                         default:

--- a/frontend/src/pages/Item/MoviePage.tsx
+++ b/frontend/src/pages/Item/MoviePage.tsx
@@ -1,7 +1,7 @@
 import type { BaseItemDto } from '@jellyfin/sdk/lib/generated-client/models';
 import BaseMediaPage from './BaseMediaPage';
 import { getPrimaryImageUrl, getLogoUrl } from '@/utils/jellyfinUrls';
-import { ImageOff } from 'lucide-react';
+import { ImageOff, Play } from 'lucide-react';
 import PeopleRow from './PeopleRow';
 import { useTranslation } from 'react-i18next';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -20,17 +20,30 @@ import ItemDownloadButton from '../../components/ItemDownloadButton';
 import SourcePickerButton from '@/components/SourcePickerButton';
 import ItemMetadataBadges from './ItemMetadataBadges';
 import Overview from './Overview';
+import { Link } from 'react-router';
+import ItemBackButton from './ItemBackButton';
 
 interface MoviePageProps {
     item: BaseItemDto;
     config: AppConfig;
+    onBack?: () => void;
 }
 
-const MoviePage = ({ item, config }: MoviePageProps) => {
+const MoviePage = ({ item, config, onBack }: MoviePageProps) => {
     const { t } = useTranslation('item');
     const [postersFailed, setPostersFailed] = useState(false);
     const [isPosterLoaded, setIsPosterLoaded] = useState(false);
     const [failedLogo, setFailedLogo] = useState(false);
+    const [customAspectRatio, setCustomAspectRatio] = useState<number | null>(null);
+    const [prevItemId, setPrevItemId] = useState<string | undefined>(item.Id);
+
+    // 切换 item 时重置自定义宽高比，避免上一张图的 ratio 残留
+    if (item.Id !== prevItemId) {
+        setPrevItemId(item.Id);
+        setCustomAspectRatio(null);
+    }
+
+    const currentAspectRatio = customAspectRatio ?? item.PrimaryImageAspectRatio ?? (2 / 3);
 
     const isCurrentlyPlaying =
         item.UserData?.PlaybackPositionTicks &&
@@ -46,35 +59,51 @@ const MoviePage = ({ item, config }: MoviePageProps) => {
             topPadding={false}
         >
             <div className="pt-24 sm:pt-32 pb-12 mx-auto w-full flex flex-col gap-12">
-                <div className="flex flex-col lg:flex-row gap-8 lg:gap-12 items-start relative z-10 w-full">
+                <div className="flex flex-col lg:flex-row gap-8 lg:gap-12 items-stretch lg:items-start relative z-10 w-full">
                     {/* Left Column (Poster) */}
-                    <div className="w-48 sm:w-64 md:w-72 lg:w-80 shrink-0 mx-auto lg:mx-0">
-                        <div className="relative aspect-2/3 w-full rounded-xl overflow-hidden shadow-2xl shadow-black/85 border border-white/10 bg-muted flex items-center justify-center">
-                            {!postersFailed ? (
-                                <>
-                                    <Skeleton className="absolute inset-0 w-full h-full rounded-xl" />
-                                    <img
-                                        src={getPrimaryImageUrl(
-                                            item.Id || '',
-                                            { width: 640, height: 960 },
-                                            item.ImageTags?.Primary
-                                        )}
-                                        alt={item.Name + ' Primary'}
-                                        className={[
-                                            'object-cover rounded-xl w-full h-full relative z-10',
-                                            'transition-[filter,opacity] duration-700 ease-out',
-                                            isPosterLoaded
-                                                ? 'blur-0 opacity-100'
-                                                : 'blur-md opacity-0',
-                                        ].join(' ')}
-                                        onLoad={() => setIsPosterLoaded(true)}
-                                        onError={() => setPostersFailed(true)}
-                                    />
-                                </>
-                            ) : (
+                    <div
+                        className="relative -mx-4 sm:mx-auto lg:mx-0 w-[calc(100%+2rem)] sm:w-full sm:max-w-[24rem] lg:max-w-[30rem] xl:max-w-[36rem] shadow-lg overflow-hidden group shrink-0 bg-black/30"
+                        style={{ aspectRatio: currentAspectRatio }}
+                    >
+                        {!postersFailed ? (
+                            <Link to={`/play/${item.Id}`} className="block w-full h-full relative cursor-pointer z-10">
+                                <Skeleton className="absolute inset-0 w-full h-full" />
+                                <img
+                                    src={getPrimaryImageUrl(
+                                        item.Id || '',
+                                        undefined,
+                                        item.ImageTags?.Primary
+                                    )}
+                                    alt={item.Name + ' Primary'}
+                                    className={[
+                                        'object-cover w-full h-full relative z-10 bg-black/20',
+                                        'transition-[filter,opacity] duration-700 ease-out',
+                                        isPosterLoaded
+                                            ? 'blur-0 opacity-100'
+                                            : 'blur-md opacity-0',
+                                    ].join(' ')}
+                                    onLoad={(e) => {
+                                        setIsPosterLoaded(true);
+                                        const img = e.currentTarget;
+                                        if (img.naturalWidth && img.naturalHeight) {
+                                            setCustomAspectRatio(img.naturalWidth / img.naturalHeight);
+                                        }
+                                    }}
+                                    onError={() => setPostersFailed(true)}
+                                />
+                                {/* 半透明大播放按钮 */}
+                                <div className="absolute inset-0 bg-black/15 md:bg-black/25 opacity-100 md:opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center z-20">
+                                    <div className="h-16 w-16 bg-white/25 md:bg-white/20 hover:bg-white/35 backdrop-blur-md border border-white/30 rounded-full flex items-center justify-center hover:scale-110 active:scale-95 transition-all duration-300 shadow-xl">
+                                        <Play className="h-8 w-8 text-white fill-white ml-1" />
+                                    </div>
+                                </div>
+                            </Link>
+                        ) : (
+                            <div className="w-full h-full flex items-center justify-center bg-muted">
                                 <ImageOff className="text-muted-foreground w-12 h-12" />
-                            )}
-                        </div>
+                            </div>
+                        )}
+                        {onBack && <ItemBackButton onClick={onBack} />}
                     </div>
 
                     {/* Right Column (Details) */}

--- a/frontend/src/pages/Item/SeasonPage.tsx
+++ b/frontend/src/pages/Item/SeasonPage.tsx
@@ -26,13 +26,15 @@ import UpcomingEpisodeComponent from './UpcomingEpisodeComponent';
 import { getLogoUrl } from '@/utils/jellyfinUrls';
 import ItemMetadataBadges from './ItemMetadataBadges';
 import Overview from './Overview';
+import ItemBackButton from './ItemBackButton';
 
 interface SeasonPageProps {
     item: BaseItemDto;
     config: AppConfig;
+    onBack?: () => void;
 }
 
-const SeasonPage = ({ item, config }: SeasonPageProps) => {
+const SeasonPage = ({ item, config, onBack }: SeasonPageProps) => {
     const { t } = useTranslation('item');
     const [selectedSeason, setSelectedSeason] = useState<string | null>(null);
     const { data: seasons, isLoading: isLoadingSeasons } = useSeasons(item.SeriesId || '');
@@ -40,6 +42,16 @@ const SeasonPage = ({ item, config }: SeasonPageProps) => {
     const { data: upcomingEpisodes } = useUpcomingEpisodes(item.Id || '');
     const [isPosterLoaded, setIsPosterLoaded] = useState(false);
     const [failedLogo, setFailedLogo] = useState(false);
+    const [customAspectRatio, setCustomAspectRatio] = useState<number | null>(null);
+    const [prevItemId, setPrevItemId] = useState<string | undefined>(item.Id);
+
+    // 切换 item 时重置自定义宽高比，避免上一张图的 ratio 残留
+    if (item.Id !== prevItemId) {
+        setPrevItemId(item.Id);
+        setCustomAspectRatio(null);
+    }
+
+    const currentAspectRatio = customAspectRatio ?? item.PrimaryImageAspectRatio ?? (2 / 3);
 
     const effectiveSelectedSeason =
         selectedSeason ||
@@ -55,36 +67,45 @@ const SeasonPage = ({ item, config }: SeasonPageProps) => {
             topPadding={false}
         >
             <div className="pt-24 sm:pt-32 pb-12 mx-auto w-full flex flex-col gap-12">
-                <div className="flex flex-col lg:flex-row gap-8 lg:gap-12 items-start relative z-10 w-full">
+                <div className="flex flex-col lg:flex-row gap-8 lg:gap-12 items-stretch lg:items-start relative z-10 w-full">
                     {/* Poster */}
-                    <div className="w-48 sm:w-64 md:w-72 lg:w-80 shrink-0 mx-auto lg:mx-0">
-                        <div className="relative aspect-2/3 w-full rounded-xl overflow-hidden shadow-2xl shadow-black/85 border border-white/10 bg-muted flex items-center justify-center">
-                            {!posterFailed ? (
-                                <>
-                                    <Skeleton className="absolute inset-0 w-full h-full rounded-xl" />
-
-                                    <img
-                                        src={getPrimaryImageUrl(
-                                            item.Id || '',
-                                            { width: 640, height: 960 },
-                                            item.ImageTags?.Primary
-                                        )}
-                                        alt={item.Name + ' Primary'}
-                                        className={[
-                                            'object-cover rounded-xl w-full h-full relative z-10',
-                                            'transition-[filter,opacity] duration-700 ease-out',
-                                            isPosterLoaded
-                                                ? 'blur-0 opacity-100'
-                                                : 'blur-md opacity-0',
-                                        ].join(' ')}
-                                        onLoad={() => setIsPosterLoaded(true)}
-                                        onError={() => setPosterFailed(true)}
-                                    />
-                                </>
-                            ) : (
+                    <div
+                        className="relative -mx-4 sm:mx-auto lg:mx-0 w-[calc(100%+2rem)] sm:w-full sm:max-w-[24rem] lg:max-w-[30rem] xl:max-w-[36rem] shadow-lg overflow-hidden group shrink-0 bg-black/30"
+                        style={{ aspectRatio: currentAspectRatio }}
+                    >
+                        {!posterFailed ? (
+                            <>
+                                <Skeleton className="absolute inset-0 w-full h-full" />
+                                <img
+                                    src={getPrimaryImageUrl(
+                                        item.Id || '',
+                                        undefined,
+                                        item.ImageTags?.Primary
+                                    )}
+                                    alt={item.Name + ' Primary'}
+                                    className={[
+                                        'object-cover w-full h-full relative z-10 bg-black/20',
+                                        'transition-[filter,opacity] duration-700 ease-out',
+                                        isPosterLoaded
+                                            ? 'blur-0 opacity-100'
+                                            : 'blur-md opacity-0',
+                                    ].join(' ')}
+                                    onLoad={(e) => {
+                                        setIsPosterLoaded(true);
+                                        const img = e.currentTarget;
+                                        if (img.naturalWidth && img.naturalHeight) {
+                                            setCustomAspectRatio(img.naturalWidth / img.naturalHeight);
+                                        }
+                                    }}
+                                    onError={() => setPosterFailed(true)}
+                                />
+                            </>
+                        ) : (
+                            <div className="w-full h-full flex items-center justify-center bg-muted">
                                 <ImageOff className="text-muted-foreground w-12 h-12" />
-                            )}
-                        </div>
+                            </div>
+                        )}
+                        {onBack && <ItemBackButton onClick={onBack} />}
                     </div>
 
                     {/* Details */}

--- a/frontend/src/pages/Item/SeriesPage.tsx
+++ b/frontend/src/pages/Item/SeriesPage.tsx
@@ -32,13 +32,15 @@ import { useUpcomingEpisodes } from '../../hooks/api/useUpcomingEpisodes';
 import UpcomingEpisodeComponent from './UpcomingEpisodeComponent';
 import ItemMetadataBadges from './ItemMetadataBadges';
 import Overview from './Overview';
+import ItemBackButton from './ItemBackButton';
 
 interface SeriesPageProps {
     item: BaseItemDto;
     config: AppConfig;
+    onBack?: () => void;
 }
 
-const SeriesPage = ({ item, config }: SeriesPageProps) => {
+const SeriesPage = ({ item, config, onBack }: SeriesPageProps) => {
     const { t } = useTranslation('item');
     const location = useLocation();
     const [selectedSeason, setSelectedSeason] = useState<string | null>(null);
@@ -46,6 +48,16 @@ const SeriesPage = ({ item, config }: SeriesPageProps) => {
     const [posterFailed, setPosterFailed] = useState(false);
     const [isPosterLoaded, setIsPosterLoaded] = useState(false);
     const [failedLogo, setFailedLogo] = useState(false);
+    const [customAspectRatio, setCustomAspectRatio] = useState<number | null>(null);
+    const [prevItemId, setPrevItemId] = useState<string | undefined>(item.Id);
+
+    // 切换 item 时重置自定义宽高比，避免上一张图的 ratio 残留
+    if (item.Id !== prevItemId) {
+        setPrevItemId(item.Id);
+        setCustomAspectRatio(null);
+    }
+
+    const currentAspectRatio = customAspectRatio ?? item.PrimaryImageAspectRatio ?? (2 / 3);
 
     const { data: upcomingEpisodes } = useUpcomingEpisodes(item.Id || '');
 
@@ -74,35 +86,45 @@ const SeriesPage = ({ item, config }: SeriesPageProps) => {
             topPadding={false}
         >
             <div className="pt-24 sm:pt-32 pb-12 mx-auto w-full flex flex-col gap-12">
-                <div className="flex flex-col lg:flex-row gap-8 lg:gap-12 items-start relative z-10 w-full">
+                <div className="flex flex-col lg:flex-row gap-8 lg:gap-12 items-stretch lg:items-start relative z-10 w-full">
                     {/* Left Column (Poster) */}
-                    <div className="w-48 sm:w-64 md:w-72 lg:w-80 shrink-0 mx-auto lg:mx-0">
-                        <div className="relative aspect-2/3 w-full rounded-xl overflow-hidden shadow-2xl shadow-black/85 border border-white/10 bg-muted flex items-center justify-center">
-                            {!posterFailed ? (
-                                <>
-                                    <Skeleton className="absolute inset-0 w-full h-full rounded-xl" />
-                                    <img
-                                        src={getPrimaryImageUrl(
-                                            item.Id || '',
-                                            { width: 640, height: 960 },
-                                            item.ImageTags?.Primary
-                                        )}
-                                        alt={item.Name + ' Primary'}
-                                        className={[
-                                            'object-cover rounded-xl w-full h-full relative z-10',
-                                            'transition-[filter,opacity] duration-700 ease-out',
-                                            isPosterLoaded
-                                                ? 'blur-0 opacity-100'
-                                                : 'blur-md opacity-0',
-                                        ].join(' ')}
-                                        onLoad={() => setIsPosterLoaded(true)}
-                                        onError={() => setPosterFailed(true)}
-                                    />
-                                </>
-                            ) : (
+                    <div
+                        className="relative -mx-4 sm:mx-auto lg:mx-0 w-[calc(100%+2rem)] sm:w-full sm:max-w-[24rem] lg:max-w-[30rem] xl:max-w-[36rem] shadow-lg overflow-hidden group shrink-0 bg-black/30"
+                        style={{ aspectRatio: currentAspectRatio }}
+                    >
+                        {!posterFailed ? (
+                            <>
+                                <Skeleton className="absolute inset-0 w-full h-full" />
+                                <img
+                                    src={getPrimaryImageUrl(
+                                        item.Id || '',
+                                        undefined,
+                                        item.ImageTags?.Primary
+                                    )}
+                                    alt={item.Name + ' Primary'}
+                                    className={[
+                                        'object-cover w-full h-full relative z-10 bg-black/20',
+                                        'transition-[filter,opacity] duration-700 ease-out',
+                                        isPosterLoaded
+                                            ? 'blur-0 opacity-100'
+                                            : 'blur-md opacity-0',
+                                    ].join(' ')}
+                                    onLoad={(e) => {
+                                        setIsPosterLoaded(true);
+                                        const img = e.currentTarget;
+                                        if (img.naturalWidth && img.naturalHeight) {
+                                            setCustomAspectRatio(img.naturalWidth / img.naturalHeight);
+                                        }
+                                    }}
+                                    onError={() => setPosterFailed(true)}
+                                />
+                            </>
+                        ) : (
+                            <div className="w-full h-full flex items-center justify-center bg-muted">
                                 <ImageOff className="text-muted-foreground w-12 h-12" />
-                            )}
-                        </div>
+                            </div>
+                        )}
+                        {onBack && <ItemBackButton onClick={onBack} />}
                     </div>
 
                     {/* Right Column (Details) */}


### PR DESCRIPTION
# Detail Page: Back Button, Cover Play Button & Cover Size Optimization

## Summary

This PR introduces three UX improvements to the item detail pages (Movie, Episode, Series, Season, BoxSet):

1. **Back button** — A floating back button on the cover that intelligently navigates the user back
2. **Cover play button** — Movie & episode covers are now clickable to start playback directly, with a hover play overlay
3. **Cover size optimization** — Cover aspect ratio is dynamically calculated from the image's natural dimensions instead of a fixed 2:3 ratio

---

## Changes

### 1. Back Button (`ItemBackButton`)

- **New component**: `frontend/src/pages/Item/ItemBackButton.tsx`
- A small floating button (top-left of the cover) with backdrop blur and fade-in animation
- **Smart navigation logic** in `ItemPage.tsx`:
  - First attempts `navigate(-1)` (browser history back) if history exists
  - Falls back to type-aware parent navigation:
    - `Episode` → Season → Series → Home
    - `Season` → Series → Parent → Home
    - `Movie` / `Series` / `BoxSet` → Parent library → Library page
- `stopPropagation` + `preventDefault` ensures the button click doesn't trigger the cover's play link

### 2. Cover Play Button (Movie & Episode only)

- The poster/thumbnail is wrapped in a `<Link to="/play/{itemId}">` making the entire cover clickable
- On hover (desktop), a semi-transparent circular play button fades in at the center
- On mobile, the play overlay is always visible (`opacity-100`)
- Applied to `MoviePage.tsx` and `EpisodePage.tsx`

### 3. Cover Size Optimization (all detail pages)

- Replaced the fixed `aspect-2/3` ratio with a dynamic `aspectRatio` style
- Reads the image's `naturalWidth` / `naturalHeight` on load and calculates the real ratio
- Falls back to `item.PrimaryImageAspectRatio`, then `2/3` as a sensible default
- Added `prevItemId` tracking to reset the ratio when navigating between items
- Enlarged responsive width classes (`sm:max-w-[24rem]` → `xl:max-w-[36rem]`) to better utilize large screens
- Applied to `MoviePage`, `EpisodePage`, `SeriesPage`, `SeasonPage`, `BoxSetPage`

---

## Files Changed

| File | Change |
|------|--------|
| `ItemBackButton.tsx` | **New** — Back button component |
| `ItemPage.tsx` | `handleBack` logic + `onBack` prop passed to child pages |
| `MoviePage.tsx` | Back button + cover play button + cover size optimization |
| `EpisodePage.tsx` | Back button + cover play button |
| `SeriesPage.tsx` | Back button + cover size optimization |
| `SeasonPage.tsx` | Back button + cover size optimization |
| `BoxSetPage.tsx` | Back button + cover size optimization |

**7 files changed, +310 / -127 lines**

---

## Screenshots

<!-- TODO: Add before/after screenshots here -->

---

## Testing

- [ ] Enter a Movie detail page → cover left-top shows back button, clicking it returns to library
- [ ] Enter an Episode detail page → cover is clickable, hover shows play button
- [ ] Enter a Series/Season/BoxSet detail page → back button works, cover ratio adapts to non-standard posters
- [ ] Navigate between items → aspect ratio resets correctly (no stale ratio from previous item)
- [ ] Mobile: play overlay is always visible on cover
- [ ] Back button click does not trigger cover play navigation
