### PR TITLE
Translate German (de)

### DIFF
--- a/packages/core/src/i18n/locales/de/library.json
+++ b/packages/core/src/i18n/locales/de/library.json
@@ -7,5 +7,11 @@
     "sort_premiere_date": "Premiere Datum",
     "sort_community_rating": "Community Bewertung",
     "sort_critic_rating": "Kritiker Bewertung",
-    "sort_runtime": "Laufzeit"
+    "sort_runtime": "Laufzeit",
+    "no_studios_found_title": "Keine Studios gefunden",
+    "no_studios_found_for_search": "Keine Studios für '{{search}}' gefunden.",
+    "no_studios_found": "Es gibt keine Studios in dieser Bibliothek.",
+    "clear_search": "Suche löschen",
+    "studios_search_placeholder": "Studios durchsuchen...",
+    "no_libraries_found": "Keine Bibliotheken gefunden."
 }

--- a/packages/core/src/i18n/locales/de/login.json
+++ b/packages/core/src/i18n/locales/de/login.json
@@ -26,5 +26,12 @@
     "quick_connect_failed": "Schnellverbindung fehlgeschlagen. Bitte versuche es erneut.",
     "quick_connect_approved": "Schnellverbindung genehmigt! Anmeldung läuft...",
     "quick_connect_timeout": "Schnellverbindung Zeitüberschreitung. Bitte versuche es erneut.",
-    "demo_warning": "Dies ist eine Demoinstanz für Pelagica. Du kannst dich mit den vorausgefüllten Anmeldedaten einloggen oder zur Serverauswahl zurückkehren, um dich mit deinem eigenen Server zu verbinden."
+    "demo_warning": "Dies ist eine Demoinstanz für Pelagica. Du kannst dich mit den vorausgefüllten Anmeldedaten einloggen oder zur Serverauswahl zurückkehren, um dich mit deinem eigenen Server zu verbinden.",
+    "sign_in_with_quick_connect": "Mit Quick Connect anmelden",
+    "sign_in_with_password": "Mit Benutzernamen und Passwort anmelden",
+    "use_different_server": "Einen anderen Server verwenden",
+    "quick_connect_qr_instructions": "Scanne diesen QR-Code und autorisiere den Code oder gehe zu {{server}} mit deinem Smartphone oder Laptop, melde dich an und giv diesen Code manuell ein.",
+    "quick_connect_unavailable": "Quick Connect ist nicht verfügbar auf diesem Server",
+    "quick_connect_auth_failed": "Quick Connect authentifizierung fehlgeschlagen",
+    "invalid_credentials": "Ungültiger Benutzername oder Passwort"
 }


### PR DESCRIPTION
Updates library, login for `de` — 576/678 strings translated overall.