### PR TITLE
Translate French (fr)

### DIFF
--- a/packages/core/src/i18n/locales/fr/common.json
+++ b/packages/core/src/i18n/locales/fr/common.json
@@ -2,6 +2,8 @@
     "previous": "Précédent",
     "next": "Suivant",
     "stats_consent_title": "Aidez-nous à compter",
+    "stats_consent_reject": "Non merci",
+    "stats_consent_accept": "Accepter",
     "cancel": "Annuler",
     "save": "Sauvegarder",
     "saving": "Enregistrement...",


### PR DESCRIPTION
Updates common for `fr` — 375/678 strings translated overall.