### PR TITLE
Translate Swedish (sv)

### DIFF
--- a/packages/core/src/i18n/locales/sv/common.json
+++ b/packages/core/src/i18n/locales/sv/common.json
@@ -1,6 +1,9 @@
 {
     "previous": "Föregående",
     "next": "Nästa",
+    "stats_consent_title": "Hjälp oss att räkna",
+    "stats_consent_reject": "Nej tack",
+    "stats_consent_accept": "Acceptera",
     "cancel": "Avboka",
     "save": "Spara",
     "saving": "Sparande...",
@@ -35,11 +38,15 @@
     "ascending": "Stigande",
     "descending": "Fallande",
     "album": "Album",
+    "albums": "Album",
+    "artist": "Artist",
     "subtitles": "Undertexter",
     "language": "Språk",
     "tags": "Taggar",
     "playlist": "Spellista",
     "no_results_found": "Inga resultat hittades",
     "category_links": "Länkar",
-    "quick_connect": "Snabbanslutning"
+    "quick_connect": "Snabbanslutning",
+    "back": "Tillbaka",
+    "close": "Stäng"
 }


### PR DESCRIPTION
Updates common for `sv` — 464/678 strings translated overall.