### PR TITLE
Translate Swedish (sv)

### DIFF
--- a/packages/core/src/i18n/locales/sv/common.json
+++ b/packages/core/src/i18n/locales/sv/common.json
@@ -1,6 +1,9 @@
 {
     "previous": "Föregående",
     "next": "Nästa",
+    "stats_consent_title": "Hjälp oss att räkna",
+    "stats_consent_reject": "Nej tack",
+    "stats_consent_accept": "Acceptera",
     "cancel": "Avboka",
     "save": "Spara",
     "saving": "Sparande...",
@@ -35,11 +38,15 @@
     "ascending": "Stigande",
     "descending": "Fallande",
     "album": "Album",
+    "albums": "Album",
+    "artist": "Artist",
     "subtitles": "Undertexter",
     "language": "Språk",
     "tags": "Taggar",
     "playlist": "Spellista",
     "no_results_found": "Inga resultat hittades",
     "category_links": "Länkar",
-    "quick_connect": "Snabbanslutning"
+    "quick_connect": "Snabbanslutning",
+    "back": "Tillbaka",
+    "close": "Stäng"
 }

--- a/packages/core/src/i18n/locales/sv/home.json
+++ b/packages/core/src/i18n/locales/sv/home.json
@@ -21,5 +21,11 @@
     "unknown_artist": "Okänd konstnär",
     "track_count": "{{count}} spår",
     "track_count_plural": "{{count}} spår",
-    "libraries": "Bibliotek"
+    "libraries": "Bibliotek",
+    "section_not_found": "Det här avsnittet kunde inte hittas.",
+    "seerr_trending": "Populärt just nu",
+    "seerr_popular_movies": "Populära filmer",
+    "seerr_popular_series": "Populära serier",
+    "error_loading_continue": "Det gick inte att läsa in Fortsätt titta: {{error}}",
+    "continue_item_alt": "Fortsätt titta"
 }


### PR DESCRIPTION
Updates common, home for `sv` — 470/678 strings translated overall.