### PR TITLE
Translate Swedish (sv)

### DIFF
--- a/packages/core/src/i18n/locales/sv/sidebar.json
+++ b/packages/core/src/i18n/locales/sv/sidebar.json
@@ -2,6 +2,8 @@
     "navigation": "Navigering",
     "home": "Hem",
     "library": "Bibliotek",
+    "music": "Musik",
+    "live": "Live",
     "theme": "Tema",
     "light": "Ljus",
     "dark": "Mörk",


### PR DESCRIPTION
Updates sidebar for `sv` — 459/678 strings translated overall.