### PR TITLE
Fix Seerr config lookup for web clients

### DIFF
--- a/backend/handlers/seerr.go
+++ b/backend/handlers/seerr.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -20,12 +19,23 @@ import (
 const seerSessionCookieName = "seer_session"
 
 func getSeerURL(c fiber.Ctx) (string, error) {
-	serverKey, err := serverKeyFromRequest(c)
-	if err != nil {
+	if _, err := serverKeyFromRequest(c); err != nil {
 		return "", err
 	}
 
-	data, err := os.ReadFile(configFilePath(serverKey))
+	jellyfinURL := strings.TrimRight(c.Query("jellyfin_url"), "/")
+
+	resp, err := http.Get(jellyfinURL + "/Pelagica/Config")
+	if err != nil {
+		return "", errors.New("failed to read config")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", errors.New("failed to read config")
+	}
+
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", errors.New("failed to read config")
 	}


### PR DESCRIPTION
Hi! This fixes the Seerr configuration issue in #170.

The web frontend stores seerrUrl in the Jellyfin Pelagica plugin config, but the Seerr backend was still looking for it in the legacy local config.json. This caused the Seerr proxy endpoints to return 502 even though Seerr was correctly configured in Pelagica.

This changes getSeerURL() to read /Pelagica/Config from the configured Jellyfin server instead, so the frontend and backend now use the same configuration source.

Tested on my Docker setup and Seerr login and requests are working correctly.

Fixes #170.