### PR TITLE
Deduplicate Jellyfin item requests with TanStack Query

### DIFF
--- a/frontend/src/components/EditItemMetadataButton.tsx
+++ b/frontend/src/components/EditItemMetadataButton.tsx
@@ -4,7 +4,6 @@ import type {
     MetadataField,
 } from '@jellyfin/sdk/lib/generated-client/models';
 import { getApi, useEditItemMetadata, useUserLibraryItem } from '@pelagica/core';
-import { getUserLibraryApi } from '@jellyfin/sdk/lib/utils/api/user-library-api';
 import { getItemUpdateApi } from '@jellyfin/sdk/lib/utils/api/item-update-api';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useState, startTransition } from 'react';

--- a/frontend/src/components/EditItemMetadataButton.tsx
+++ b/frontend/src/components/EditItemMetadataButton.tsx
@@ -1,10 +1,9 @@
-import { useEditItemMetadata } from '@pelagica/core';
 import type {
     BaseItemDto,
     Video3DFormat,
     MetadataField,
 } from '@jellyfin/sdk/lib/generated-client/models';
-import { getApi } from '@pelagica/core';
+import { getApi, useEditItemMetadata, useUserLibraryItem } from '@pelagica/core';
 import { getUserLibraryApi } from '@jellyfin/sdk/lib/utils/api/user-library-api';
 import { getItemUpdateApi } from '@jellyfin/sdk/lib/utils/api/item-update-api';
 import { useQuery } from '@tanstack/react-query';
@@ -82,14 +81,7 @@ const EditItemMetadataButton = ({
     });
 
     // ---- fetch full item when dialog opens ----
-    const { data: fullItem } = useQuery({
-        queryKey: ['fullItem', item.Id],
-        queryFn: async () => {
-            const api = getApi();
-            return (await getUserLibraryApi(api).getItem({ itemId: item.Id! })).data;
-        },
-        enabled: isEditDialogOpen && !!item.Id,
-    });
+    const { data: fullItem } = useUserLibraryItem(isEditDialogOpen ? item.Id : undefined);
 
     const { data: metadataEditorInfo } = useQuery({
         queryKey: ['metadataEditorInfo', item.Id],

--- a/packages/core/src/hooks/playState/useItemPlayState.ts
+++ b/packages/core/src/hooks/playState/useItemPlayState.ts
@@ -1,29 +1,16 @@
-import { useQuery } from '@tanstack/react-query';
-import { getUserLibraryApi } from '@jellyfin/sdk/lib/utils/api/user-library-api';
-import { getApi } from '../../api/getApi';
+import { useUserLibraryItem } from '../useUserLibraryItem';
 
 export function useItemPlayState(itemId: string | undefined, userId: string | undefined) {
-    return useQuery({
-        queryKey: ['itemPlayState', userId, itemId],
-        enabled: !!userId && !!itemId,
-        queryFn: async () => {
-            if (!itemId || !userId) {
-                throw new Error('Missing itemId or userId');
-            }
+    const query = useUserLibraryItem(itemId, userId);
 
-            const api = getApi();
-            const userLibraryApi = getUserLibraryApi(api);
-
-            const { data } = await userLibraryApi.getItem({
-                userId,
-                itemId,
-            });
-
-            return {
-                played: data.UserData?.Played ?? false,
-                playCount: data.UserData?.PlayCount ?? 0,
-                lastPlayedDate: data.UserData?.LastPlayedDate ?? null,
-            };
-        },
-    });
+    return {
+        ...query,
+        data: query.data
+            ? {
+                  played: query.data.UserData?.Played ?? false,
+                  playCount: query.data.UserData?.PlayCount ?? 0,
+                  lastPlayedDate: query.data.UserData?.LastPlayedDate ?? null,
+              }
+            : undefined,
+    };
 }

--- a/packages/core/src/hooks/playState/useMarkItemPlayed.ts
+++ b/packages/core/src/hooks/playState/useMarkItemPlayed.ts
@@ -26,7 +26,7 @@ export function useMarkItemPlayed() {
         },
         onSuccess: (_, { itemId, userId }) => {
             queryClient.invalidateQueries({
-                queryKey: ['itemPlayState', userId, itemId],
+                queryKey: ['userLibraryItem', itemId, userId],
             });
             queryClient.invalidateQueries({
                 queryKey: ['item', itemId],

--- a/packages/core/src/hooks/playState/useMarkItemUnplayed.ts
+++ b/packages/core/src/hooks/playState/useMarkItemUnplayed.ts
@@ -24,7 +24,7 @@ export function useMarkItemUnplayed() {
         },
         onSuccess: (_, { itemId, userId }) => {
             queryClient.invalidateQueries({
-                queryKey: ['itemPlayState', userId, itemId],
+                queryKey: ['userLibraryItem', itemId, userId],
             });
             queryClient.invalidateQueries({
                 queryKey: ['item', itemId],

--- a/packages/core/src/hooks/useDeleteMedia.ts
+++ b/packages/core/src/hooks/useDeleteMedia.ts
@@ -14,6 +14,7 @@ export function useDeleteMedia(onSuccess?: () => void) {
             return itemId;
         },
         onSuccess: (deletedItemId) => {
+            queryClient.invalidateQueries({ queryKey: ['userLibraryItem', deletedItemId] });
             queryClient.invalidateQueries({ queryKey: ['item', deletedItemId] });
             queryClient.invalidateQueries({ queryKey: ['items'] });
             queryClient.invalidateQueries({ queryKey: ['libraryItems'] });

--- a/packages/core/src/hooks/useEditItemMetadata.ts
+++ b/packages/core/src/hooks/useEditItemMetadata.ts
@@ -26,6 +26,7 @@ export function useEditItemMetadata(onSuccess?: () => void) {
             return itemId;
         },
         onSuccess: (itemId) => {
+            queryClient.invalidateQueries({ queryKey: ['userLibraryItem', itemId] });
             queryClient.invalidateQueries({ queryKey: ['item', itemId] });
             queryClient.invalidateQueries({ queryKey: ['playerItem', itemId] });
             queryClient.invalidateQueries({ queryKey: ['items'] });

--- a/packages/core/src/hooks/useFavorite.ts
+++ b/packages/core/src/hooks/useFavorite.ts
@@ -1,30 +1,20 @@
 import { getApi } from '../api/getApi';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { getUserLibraryApi } from '@jellyfin/sdk/lib/utils/api/user-library-api';
-import { getRetryConfig } from '../utils/authErrorHandler';
+import { useUserLibraryItem } from './useUserLibraryItem';
 
 export function useFavorite(itemId: string | null | undefined) {
     const queryClient = useQueryClient();
 
-    const { data: isFavorite = false, isLoading: isFavoriteLoading } = useQuery({
-        queryKey: ['favorite', itemId],
-        queryFn: async (): Promise<boolean> => {
-            if (!itemId) return false;
-            const api = getApi();
-            const userLibraryApi = getUserLibraryApi(api);
-            const response = await userLibraryApi.getItem({ itemId });
-            return response.data.UserData?.IsFavorite ?? false;
-        },
-        enabled: !!itemId,
-        ...getRetryConfig(),
-    });
+    const { data: item, isLoading: isFavoriteLoading } = useUserLibraryItem(itemId);
+
+    const isFavorite = item?.UserData?.IsFavorite ?? false;
 
     const { mutate: toggleFavorite, isPending: isToggling } = useMutation({
         mutationFn: async (favorite: boolean) => {
             if (!itemId) throw new Error('Item ID is required');
             const api = getApi();
             const userLibraryApi = getUserLibraryApi(api);
-
             if (favorite) {
                 await userLibraryApi.markFavoriteItem({ itemId });
             } else {
@@ -32,8 +22,10 @@ export function useFavorite(itemId: string | null | undefined) {
             }
             return favorite;
         },
-        onSuccess: (newFavoriteState) => {
-            queryClient.setQueryData(['favorite', itemId], newFavoriteState);
+        onSuccess: () => {
+            queryClient.invalidateQueries({
+                queryKey: ['userLibraryItem', itemId],
+            });
             queryClient.invalidateQueries({ queryKey: ['item', itemId] });
             queryClient.invalidateQueries({ queryKey: ['favoriteAlbums'] });
             queryClient.invalidateQueries({ queryKey: ['favoriteArtists'] });

--- a/packages/core/src/hooks/useFavorite.ts
+++ b/packages/core/src/hooks/useFavorite.ts
@@ -23,9 +23,7 @@ export function useFavorite(itemId: string | null | undefined) {
             return favorite;
         },
         onSuccess: () => {
-            queryClient.invalidateQueries({
-                queryKey: ['userLibraryItem', itemId],
-            });
+            queryClient.invalidateQueries({ queryKey: ['userLibraryItem', itemId] });
             queryClient.invalidateQueries({ queryKey: ['item', itemId] });
             queryClient.invalidateQueries({ queryKey: ['favoriteAlbums'] });
             queryClient.invalidateQueries({ queryKey: ['favoriteArtists'] });

--- a/packages/core/src/hooks/useLike.ts
+++ b/packages/core/src/hooks/useLike.ts
@@ -1,23 +1,14 @@
 import { getApi } from '../api/getApi';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { getUserLibraryApi } from '@jellyfin/sdk/lib/utils/api/user-library-api';
-import { getRetryConfig } from '../utils/authErrorHandler';
+import { useUserLibraryItem } from './useUserLibraryItem';
 
 export function useLike(itemId: string | null | undefined) {
     const queryClient = useQueryClient();
 
-    const { data: isLiked = false, isLoading: isLikedLoading } = useQuery({
-        queryKey: ['like', itemId],
-        queryFn: async (): Promise<boolean> => {
-            if (!itemId) return false;
-            const api = getApi();
-            const userLibraryApi = getUserLibraryApi(api);
-            const response = await userLibraryApi.getItem({ itemId });
-            return response.data.UserData?.Likes ?? false;
-        },
-        enabled: !!itemId,
-        ...getRetryConfig(),
-    });
+    const { data: item, isLoading: isLikedLoading } = useUserLibraryItem(itemId);
+
+    const isLiked = item?.UserData?.Likes ?? false;
 
     const { mutate: toggleLike, isPending: isUpdating } = useMutation({
         mutationFn: async (like: boolean) => {
@@ -27,8 +18,10 @@ export function useLike(itemId: string | null | undefined) {
             await userLibraryApi.updateUserItemRating({ itemId, likes: like });
             return like;
         },
-        onSuccess: (newLikeState) => {
-            queryClient.setQueryData(['like', itemId], newLikeState);
+        onSuccess: () => {
+            queryClient.invalidateQueries({
+                queryKey: ['userLibraryItem', itemId],
+            });
             queryClient.invalidateQueries({ queryKey: ['item', itemId] });
         },
     });

--- a/packages/core/src/hooks/useLike.ts
+++ b/packages/core/src/hooks/useLike.ts
@@ -19,9 +19,7 @@ export function useLike(itemId: string | null | undefined) {
             return like;
         },
         onSuccess: () => {
-            queryClient.invalidateQueries({
-                queryKey: ['userLibraryItem', itemId],
-            });
+            queryClient.invalidateQueries({ queryKey: ['userLibraryItem', itemId] });
             queryClient.invalidateQueries({ queryKey: ['item', itemId] });
         },
     });

--- a/packages/core/src/hooks/usePerson.ts
+++ b/packages/core/src/hooks/usePerson.ts
@@ -1,27 +1,7 @@
-import { getApi } from '../api/getApi';
-import { useQuery } from '@tanstack/react-query';
-import { getUserLibraryApi } from '@jellyfin/sdk/lib/utils/api/user-library-api';
-import type { BaseItemDto } from '@jellyfin/sdk/lib/generated-client/models';
-import { getRetryConfig } from '../utils/authErrorHandler';
+import { useUserLibraryItem } from './useUserLibraryItem';
 
 export function usePerson(itemId: string | null | undefined, userId?: string | undefined) {
-    return useQuery<BaseItemDto>({
-        queryKey: ['person', itemId],
-        queryFn: async (): Promise<BaseItemDto> => {
-            const api = getApi();
-            const userLibraryApi = getUserLibraryApi(api);
-            const response = await userLibraryApi.getItem({
-                itemId: itemId!,
-                userId,
-            });
-            const item = response.data;
-            if (!item) {
-                throw new Error(`Item not found: ${itemId}`);
-            }
-            return item;
-        },
-        enabled: !!itemId,
-        ...getRetryConfig(),
+    return useUserLibraryItem(itemId, userId, {
         staleTime: 5 * 60 * 1000,
         gcTime: 30 * 60 * 1000,
     });

--- a/packages/core/src/hooks/useRefreshItemMetadata.ts
+++ b/packages/core/src/hooks/useRefreshItemMetadata.ts
@@ -41,6 +41,7 @@ export function useRefreshItemMetadata(onSuccess?: () => void) {
             return itemId;
         },
         onSuccess: (itemId) => {
+            queryClient.invalidateQueries({ queryKey: ['userLibraryItem', itemId] });
             queryClient.invalidateQueries({ queryKey: ['item', itemId] });
             queryClient.invalidateQueries({ queryKey: ['playerItem', itemId] });
             queryClient.invalidateQueries({ queryKey: ['items'] });

--- a/packages/core/src/hooks/useUserLibraryItem.ts
+++ b/packages/core/src/hooks/useUserLibraryItem.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import type { BaseItemDto } from '@jellyfin/sdk/lib/generated-client/models';
 import { getUserLibraryApi } from '@jellyfin/sdk/lib/utils/api/user-library-api';
 import { getApi } from '../api/getApi';
 import { getRetryConfig } from '../utils/authErrorHandler';
@@ -16,7 +17,7 @@ export function useUserLibraryItem(
 ) {
     const resolvedUserId = userId ?? getUserId() ?? undefined;
 
-    return useQuery({
+    return useQuery<BaseItemDto>({
         queryKey: ['userLibraryItem', itemId, resolvedUserId],
         queryFn: async () => {
             if (!itemId) {

--- a/packages/core/src/hooks/useUserLibraryItem.ts
+++ b/packages/core/src/hooks/useUserLibraryItem.ts
@@ -3,9 +3,15 @@ import { getUserLibraryApi } from '@jellyfin/sdk/lib/utils/api/user-library-api'
 import { getApi } from '../api/getApi';
 import { getRetryConfig } from '../utils/authErrorHandler';
 
+interface UserLibraryItemQueryOptions {
+    staleTime?: number;
+    gcTime?: number;
+}
+
 export function useUserLibraryItem(
     itemId: string | null | undefined,
-    userId?: string | undefined
+    userId?: string | undefined,
+    options?: UserLibraryItemQueryOptions
 ) {
     return useQuery({
         queryKey: ['userLibraryItem', itemId, userId],
@@ -26,6 +32,7 @@ export function useUserLibraryItem(
         },
         enabled: !!itemId,
         ...getRetryConfig(),
-        staleTime: 30_000,
+        staleTime: options?.staleTime ?? 30_000,
+        gcTime: options?.gcTime,
     });
 }

--- a/packages/core/src/hooks/useUserLibraryItem.ts
+++ b/packages/core/src/hooks/useUserLibraryItem.ts
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query';
+import { getUserLibraryApi } from '@jellyfin/sdk/lib/utils/api/user-library-api';
+import { getApi } from '../api/getApi';
+import { getRetryConfig } from '../utils/authErrorHandler';
+
+export function useUserLibraryItem(
+    itemId: string | null | undefined,
+    userId?: string | undefined
+) {
+    return useQuery({
+        queryKey: ['userLibraryItem', itemId, userId],
+        queryFn: async () => {
+            if (!itemId) {
+                throw new Error('Item ID is required');
+            }
+
+            const api = getApi();
+            const userLibraryApi = getUserLibraryApi(api);
+
+            const response = await userLibraryApi.getItem({
+                itemId,
+                userId,
+            });
+
+            return response.data;
+        },
+        enabled: !!itemId,
+        ...getRetryConfig(),
+        staleTime: 30_000,
+    });
+}

--- a/packages/core/src/hooks/useUserLibraryItem.ts
+++ b/packages/core/src/hooks/useUserLibraryItem.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { getUserLibraryApi } from '@jellyfin/sdk/lib/utils/api/user-library-api';
 import { getApi } from '../api/getApi';
 import { getRetryConfig } from '../utils/authErrorHandler';
+import { getUserId } from '../utils/localstorageCredentials';
 
 interface UserLibraryItemQueryOptions {
     staleTime?: number;
@@ -13,8 +14,10 @@ export function useUserLibraryItem(
     userId?: string | undefined,
     options?: UserLibraryItemQueryOptions
 ) {
+    const resolvedUserId = userId ?? getUserId() ?? undefined;
+
     return useQuery({
-        queryKey: ['userLibraryItem', itemId, userId],
+        queryKey: ['userLibraryItem', itemId, resolvedUserId],
         queryFn: async () => {
             if (!itemId) {
                 throw new Error('Item ID is required');
@@ -25,7 +28,7 @@ export function useUserLibraryItem(
 
             const response = await userLibraryApi.getItem({
                 itemId,
-                userId,
+                userId: resolvedUserId,
             });
 
             return response.data;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -99,6 +99,7 @@ export * from './hooks/useSimilarItems';
 export * from './hooks/useStudioItems';
 export * from './hooks/useStudiosApi';
 export * from './hooks/useUpcomingEpisodes';
+export * from './hooks/useUserLibraryItem';
 export * from './hooks/useUserViews';
 export * from './types/items';
 export * from './types/locales';


### PR DESCRIPTION
Thanks for the feedback on #211. I've reworked the fix to use TanStack Query's existing caching and request deduplication rather than adding a separate cache layer.

The original issue was that useLike, useFavorite, usePerson and useItemPlayState each queried the same Jellyfin item independently under different query keys. In my original HAR this resulted in 252 GET /Items/{id} requests for 63 unique items, with each item requested four times.

This version moves those consumers onto a shared useUserLibraryItem query, with a consistent item/user query key, and updates the relevant mutations to invalidate that shared query when the underlying item or user data changes. Specialized getItems() queries remain separate.

I tested the new implementation with two fresh HAR captures, both with and without browser caching. In both cases the previous four-request bursts were gone, with no redundant instances of the original single-item request pattern observed.

This should keep the fix within the existing TanStack Query architecture while still addressing the duplicate Jellyfin requests. Thanks again for the suggestion!