### PR TITLE
Bugfix: user password trimmed when attempting login

### DIFF
--- a/frontend/src/pages/Login/LoginPage.tsx
+++ b/frontend/src/pages/Login/LoginPage.tsx
@@ -205,7 +205,7 @@ const LoginPage = () => {
         const usernameInput = form.querySelector('#username') as HTMLInputElement;
         const passwordInput = form.querySelector('#password') as HTMLInputElement;
         const username = usernameInput?.value?.trim();
-        const password = passwordInput?.value?;
+        const password = passwordInput?.value;
 
         if (!username) {
             setLoginError(t('enter_at_least_username'));

--- a/frontend/src/pages/Login/LoginPage.tsx
+++ b/frontend/src/pages/Login/LoginPage.tsx
@@ -205,7 +205,7 @@ const LoginPage = () => {
         const usernameInput = form.querySelector('#username') as HTMLInputElement;
         const passwordInput = form.querySelector('#password') as HTMLInputElement;
         const username = usernameInput?.value?.trim();
-        const password = passwordInput?.value?.trim();
+        const password = passwordInput?.value?;
 
         if (!username) {
             setLoginError(t('enter_at_least_username'));


### PR DESCRIPTION
The login form currently trims whitespaces off the username and password fields. While it is standard practice for usernames, whitespaces should not be trimmed off the provided password. Such behavior prevents login when the password includes whitespaces at the beginning or the end of the string -- which was my case 15 minutes ago.