### PR TITLE
feat(desktop): remember window state and behave as a single instance

### DIFF
--- a/desktop/app_icon_service.go
+++ b/desktop/app_icon_service.go
@@ -3,7 +3,6 @@ package main
 import (
 	"embed"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/wailsapp/wails/v3/pkg/application"
@@ -74,15 +73,7 @@ func applySavedAppIcon() {
 }
 
 func appIconPreferencePath() (string, error) {
-	dir, err := os.UserConfigDir()
-	if err != nil {
-		return "", err
-	}
-	dir = filepath.Join(dir, "Pelagica")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, "app-icon.txt"), nil
+	return configFilePath("app-icon.txt")
 }
 
 func readAppIconPreference() (string, error) {

--- a/desktop/config_path.go
+++ b/desktop/config_path.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// configFilePath returns a path in the app's per-user config directory, creating it if needed.
+func configFilePath(name string) (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	dir = filepath.Join(dir, "Pelagica")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, name), nil
+}

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"runtime"
+	"sync"
 
 	"github.com/wailsapp/wails/v3/pkg/application"
 	"github.com/wailsapp/wails/v3/pkg/events"
@@ -12,6 +13,11 @@ import (
 
 //go:embed all:frontend/dist
 var assets embed.FS
+
+const (
+	windowMinWidth  = 640
+	windowMinHeight = 480
+)
 
 func newAssetHandler() http.Handler {
 	mux := http.NewServeMux()
@@ -26,6 +32,7 @@ func main() {
 
 	windowService := &WindowService{}
 	appIconService := &AppIconService{}
+	stateTracker := &windowStateTracker{}
 
 	app := application.New(application.Options{
 		Name:        "Pelagica",
@@ -40,12 +47,15 @@ func main() {
 		Mac: application.MacOptions{
 			ApplicationShouldTerminateAfterLastWindowClosed: true,
 		},
+		OnShutdown: stateTracker.flush,
 	})
 
-	window := app.Window.NewWithOptions(application.WebviewWindowOptions{
+	windowOptions := application.WebviewWindowOptions{
 		Title:     "Pelagica",
 		Width:     1280,
 		Height:    800,
+		MinWidth:  windowMinWidth,
+		MinHeight: windowMinHeight,
 		URL:       "/",
 		Frameless: runtime.GOOS != "darwin", // macOS keeps framed, it's just inset so traggic light stays there
 		Mac: application.MacWindow{
@@ -55,12 +65,18 @@ func main() {
 				FullscreenEnabled: application.Enabled,
 			},
 		},
-	})
-	windowService.window = window
+	}
+	stateTracker.applySavedState(&windowOptions)
 
+	window := app.Window.NewWithOptions(windowOptions)
+	windowService.window = window
+	stateTracker.registerHooks(window)
+
+	var onFirstShow sync.Once
 	window.RegisterHook(events.Common.WindowShow, func(*application.WindowEvent) {
 		windowService.positionTrafficLights()
 		applySavedAppIcon()
+		onFirstShow.Do(func() { ensureWindowOnScreen(app, window) })
 	})
 	window.RegisterHook(events.Common.WindowDidResize, func(*application.WindowEvent) {
 		windowService.positionTrafficLights()

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -51,6 +51,9 @@ func main() {
 		Mac: application.MacOptions{
 			ApplicationShouldTerminateAfterLastWindowClosed: true,
 		},
+		Windows: application.WindowsOptions{
+			AdditionalBrowserArgs: []string{"--autoplay-policy=no-user-gesture-required"},
+		},
 		OnShutdown: stateTracker.flush,
 		SingleInstance: &application.SingleInstanceOptions{
 			UniqueID: "app.pelagica.desktop",
@@ -72,7 +75,10 @@ func main() {
 			TitleBar:                application.MacTitleBarHiddenInset,
 			InvisibleTitleBarHeight: 50,
 			WebviewPreferences: application.MacWebviewPreferences{
-				FullscreenEnabled: application.Enabled,
+				FullscreenEnabled:               application.Enabled,
+				EnableAutoplayWithoutUserAction: application.Enabled,
+				AllowsAirPlayForMediaPlayback:   application.Enabled,
+				ApplicationNameForUserAgent:     "Pelagica",
 			},
 		},
 	}

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -14,6 +14,9 @@ import (
 //go:embed all:frontend/dist
 var assets embed.FS
 
+//go:embed build/appicon.png
+var appIcon []byte
+
 const (
 	windowMinWidth  = 640
 	windowMinHeight = 480
@@ -37,6 +40,7 @@ func main() {
 	app := application.New(application.Options{
 		Name:        "Pelagica",
 		Description: "A modern cross-platform desktop client for Jellyfin",
+		Icon:        appIcon,
 		Services: []application.Service{
 			application.NewService(windowService),
 			application.NewService(appIconService),

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -48,6 +48,12 @@ func main() {
 			ApplicationShouldTerminateAfterLastWindowClosed: true,
 		},
 		OnShutdown: stateTracker.flush,
+		SingleInstance: &application.SingleInstanceOptions{
+			UniqueID: "app.pelagica.desktop",
+			OnSecondInstanceLaunch: func(application.SecondInstanceData) {
+				windowService.raise()
+			},
+		},
 	})
 
 	windowOptions := application.WebviewWindowOptions{

--- a/desktop/studios_db.go
+++ b/desktop/studios_db.go
@@ -60,13 +60,12 @@ func normalizeStudioName(name string) string {
 }
 
 // studiosDBDir returns (and creates) the per-user directory used to cache the
-// downloaded studios database, mirroring appIconPreferencePath's convention.
+// downloaded studios database.
 func studiosDBDir() (string, error) {
-	dir, err := os.UserConfigDir()
+	dir, err := configFilePath("studios-db")
 	if err != nil {
 		return "", err
 	}
-	dir = filepath.Join(dir, "Pelagica", "studios-db")
 	if err := os.MkdirAll(filepath.Join(dir, studiosDBTempSubdir), 0o755); err != nil {
 		return "", err
 	}

--- a/desktop/window_service.go
+++ b/desktop/window_service.go
@@ -35,6 +35,17 @@ func (s *WindowService) positionTrafficLights() {
 	})
 }
 
+// raise brings the existing window to the front. Restore() is avoided: it would drop the
+// window out of fullscreen.
+func (s *WindowService) raise() {
+	if s.window == nil {
+		return
+	}
+	s.window.UnMinimise()
+	s.window.Show()
+	s.window.Focus()
+}
+
 // ToggleFullscreen toggles native window fullscreen.
 func (s *WindowService) ToggleFullscreen() {
 	s.window.ToggleFullscreen()

--- a/desktop/window_state.go
+++ b/desktop/window_state.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/wailsapp/wails/v3/pkg/application"
+	"github.com/wailsapp/wails/v3/pkg/events"
+)
+
+const (
+	windowStateFileName = "window-state.json"
+	// Coalesces a drag into one measurement, and lets the maximise or fullscreen
+	// notification arrive first: the platform posts those after the resize they belong to.
+	windowStateSettleDelay = time.Second
+	minVisibleWidth        = 200
+	minVisibleHeight       = 100
+	windowStateEpsilon     = 1
+)
+
+// windowState carries the window's normal bounds between launches, never its maximised,
+// fullscreen or minimised ones.
+type windowState struct {
+	X         int  `json:"x"`
+	Y         int  `json:"y"`
+	Width     int  `json:"width"`
+	Height    int  `json:"height"`
+	Maximised bool `json:"maximised"`
+}
+
+type windowStateTracker struct {
+	window *application.WebviewWindow
+
+	mu          sync.Mutex
+	state       windowState
+	maximised   bool
+	fullscreen  bool
+	minimised   bool
+	dirty       bool
+	settleTimer *time.Timer
+}
+
+func (t *windowStateTracker) applySavedState(options *application.WebviewWindowOptions) {
+	saved, ok := loadWindowState()
+	if !ok {
+		return
+	}
+	t.state = saved
+	// A restored window is maximised before any event says so.
+	t.maximised = saved.Maximised
+
+	options.Width = saved.Width
+	options.Height = saved.Height
+	options.X = saved.X
+	options.Y = saved.Y
+	options.InitialPosition = application.WindowXY
+	if saved.Maximised {
+		options.StartState = application.WindowStateMaximised
+	}
+}
+
+func (t *windowStateTracker) registerHooks(window *application.WebviewWindow) {
+	t.window = window
+
+	window.RegisterHook(events.Common.WindowDidResize, func(*application.WindowEvent) { t.record() })
+	window.RegisterHook(events.Common.WindowDidMove, func(*application.WindowEvent) { t.record() })
+
+	window.RegisterHook(events.Common.WindowMaximise, func(*application.WindowEvent) { t.setMaximised(true) })
+	window.RegisterHook(events.Common.WindowUnMaximise, func(*application.WindowEvent) { t.setMaximised(false) })
+	window.RegisterHook(events.Common.WindowFullscreen, func(*application.WindowEvent) { t.setFlag(&t.fullscreen, true) })
+	window.RegisterHook(events.Common.WindowUnFullscreen, func(*application.WindowEvent) { t.setFlag(&t.fullscreen, false) })
+	window.RegisterHook(events.Common.WindowMinimise, func(*application.WindowEvent) { t.setFlag(&t.minimised, true) })
+	window.RegisterHook(events.Common.WindowUnMinimise, func(*application.WindowEvent) { t.setFlag(&t.minimised, false) })
+}
+
+func (t *windowStateTracker) record() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.scheduleSettleLocked()
+}
+
+// Must be called with the lock held.
+func (t *windowStateTracker) scheduleSettleLocked() {
+	if t.settleTimer != nil {
+		t.settleTimer.Stop()
+	}
+	t.settleTimer = time.AfterFunc(windowStateSettleDelay, func() { t.settle() })
+}
+
+func (t *windowStateTracker) settle() {
+	t.mu.Lock()
+	window := t.window
+	skip := window == nil || t.maximised || t.fullscreen || t.minimised
+	t.settleTimer = nil
+	t.mu.Unlock()
+
+	if !skip {
+		// Bounds() hops onto the main thread, so it must not run under the lock.
+		if bounds := window.Bounds(); bounds.Width > 0 && bounds.Height > 0 {
+			t.mu.Lock()
+			if !withinEpsilon(bounds, t.state) {
+				t.state.X = bounds.X
+				t.state.Y = bounds.Y
+				t.state.Width = bounds.Width
+				t.state.Height = bounds.Height
+				t.dirty = true
+			}
+			t.mu.Unlock()
+		}
+	}
+
+	t.write()
+}
+
+// withinEpsilon absorbs the rounding a read-back applies to the stored geometry.
+func withinEpsilon(bounds application.Rect, state windowState) bool {
+	return abs(bounds.X-state.X) <= windowStateEpsilon &&
+		abs(bounds.Y-state.Y) <= windowStateEpsilon &&
+		abs(bounds.Width-state.Width) <= windowStateEpsilon &&
+		abs(bounds.Height-state.Height) <= windowStateEpsilon
+}
+
+func abs(v int) int {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+func (t *windowStateTracker) setMaximised(maximised bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.maximised = maximised
+	t.state.Maximised = maximised
+	t.dirty = true
+	t.scheduleSettleLocked()
+}
+
+func (t *windowStateTracker) setFlag(flag *bool, value bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	*flag = value
+}
+
+// flush measures and writes anything pending, for a quit inside the settle delay.
+func (t *windowStateTracker) flush() {
+	t.mu.Lock()
+	pending := t.settleTimer != nil
+	if pending {
+		t.settleTimer.Stop()
+		t.settleTimer = nil
+	}
+	t.mu.Unlock()
+
+	if pending {
+		t.settle()
+		return
+	}
+	t.write()
+}
+
+func (t *windowStateTracker) write() {
+	t.mu.Lock()
+	if !t.dirty {
+		t.mu.Unlock()
+		return
+	}
+	t.dirty = false
+	state := t.state
+	t.mu.Unlock()
+
+	saveWindowState(state)
+}
+
+// ensureWindowOnScreen brings a restored window back onto a connected display.
+func ensureWindowOnScreen(app *application.App, window *application.WebviewWindow) {
+	bounds := window.Bounds()
+	if bounds.Width <= 0 || bounds.Height <= 0 {
+		return
+	}
+
+	screens := app.Screen.GetAll()
+	if len(screens) == 0 {
+		return
+	}
+
+	area, visible := hostScreen(bounds, screens)
+
+	// Geometry from a larger display would hang off this one, putting the player controls
+	// out of reach.
+	width := min(bounds.Width, area.Width)
+	height := min(bounds.Height, area.Height)
+	if width != bounds.Width || height != bounds.Height {
+		window.SetSize(width, height)
+		visible = false
+	}
+
+	if !visible {
+		window.Center()
+	}
+}
+
+func hostScreen(bounds application.Rect, screens []*application.Screen) (application.Rect, bool) {
+	for _, screen := range screens {
+		if isUsablyVisible(bounds, screen.WorkArea) {
+			return screen.WorkArea, true
+		}
+	}
+	return screens[0].WorkArea, false
+}
+
+// isUsablyVisible reports whether enough overlaps for the user to grab the window back.
+func isUsablyVisible(bounds, area application.Rect) bool {
+	overlapWidth := min(bounds.X+bounds.Width, area.X+area.Width) - max(bounds.X, area.X)
+	overlapHeight := min(bounds.Y+bounds.Height, area.Y+area.Height) - max(bounds.Y, area.Y)
+	return overlapWidth >= minVisibleWidth && overlapHeight >= minVisibleHeight
+}
+
+func loadWindowState() (windowState, bool) {
+	path, err := configFilePath(windowStateFileName)
+	if err != nil {
+		return windowState{}, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return windowState{}, false
+	}
+	var state windowState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return windowState{}, false
+	}
+	if state.Width < windowMinWidth || state.Height < windowMinHeight {
+		return windowState{}, false
+	}
+	return state, true
+}
+
+func saveWindowState(state windowState) {
+	path, err := configFilePath(windowStateFileName)
+	if err != nil {
+		return
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(path, data, 0o644)
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,12 +1,17 @@
 import { createRoot } from 'react-dom/client';
 import { setClientInfo } from '@pelagica/core';
 import App from './App.tsx';
+import { isDesktopBuild } from './utils/desktopApp.ts';
 import { VERSION } from './utils/version.ts';
 
 import './index.css';
 import './theme.css';
 import '@pelagica/core/i18n';
 
-setClientInfo({ name: 'Pelagica', version: VERSION });
+if (isDesktopBuild) {
+    setClientInfo({ name: 'Pelagica Desktop', version: VERSION, platform: 'desktop' });
+} else {
+    setClientInfo({ name: 'Pelagica', version: VERSION });
+}
 
 createRoot(document.getElementById('root')!).render(<App />);

--- a/frontend/src/utils/desktopApp.ts
+++ b/frontend/src/utils/desktopApp.ts
@@ -9,7 +9,7 @@ export function isMacOS(): boolean {
     return typeof navigator !== 'undefined' && /Mac/i.test(navigator.userAgent);
 }
 
-const isDesktopBuild = import.meta.env.VITE_IS_DESKTOP_BUILD === 'true';
+export const isDesktopBuild = import.meta.env.VITE_IS_DESKTOP_BUILD === 'true';
 
 /**
  * Intercepts a click on an external link and opens it in the user's default browser if the app is running in desktop mode.

--- a/packages/core/src/api/jellyfinClient.ts
+++ b/packages/core/src/api/jellyfinClient.ts
@@ -1,7 +1,7 @@
 import { Jellyfin } from '@jellyfin/sdk';
 import { getDeviceId } from '../utils/deviceId';
 
-export type Platform = 'web' | 'tizen' | 'webos';
+export type Platform = 'web' | 'tizen' | 'webos' | 'desktop';
 
 export interface PlatformCapabilities {
     /** Direct-play containers this platforms player supports beyond the browser default mp4/webm. */
@@ -23,11 +23,24 @@ const PLATFORM_CAPABILITIES: Record<Platform, PlatformCapabilities> = {
         extraDirectPlayContainers: [],
         extraDirectPlayAudioCodecs: [],
     },
+    desktop: {
+        extraDirectPlayContainers: [],
+        extraDirectPlayAudioCodecs: [],
+    },
 };
+
+function getDesktopOsName(): string {
+    const ua = navigator.userAgent;
+    if (ua.includes('Windows')) return 'Windows';
+    if (ua.includes('Macintosh')) return 'macOS';
+    if (ua.includes('Linux')) return 'Linux';
+    return 'Desktop';
+}
 
 function getBrowserName(): string {
     if (platform === 'tizen') return 'Samsung Smart TV';
     if (platform === 'webos') return 'LG webOS';
+    if (platform === 'desktop') return getDesktopOsName();
 
     const ua = navigator.userAgent;
     if (ua.includes('Firefox/')) return 'Firefox';


### PR DESCRIPTION
- remember last window size when reopening (if it was opened on a bigger screen than the current one, make it fit the current window
- trying to open a second window will bring the currently opened window to the foreground
- report the desktop build as its own Jellyfin client, named for the OS it runs on
- embed the app icon in the binary, so the Dock shows Pelagica when running unbundled and Windows and Linux get a window icon (wasn't able to test Windows and Linux, but they should work)

I tested all the changes except the Windows/Linux one since I don't have a Windows/Linux machine.

Let me know if you want any changes