### PR TITLE
feat(player): add airplay support

### DIFF
--- a/frontend/src/hooks/useAirPlay.ts
+++ b/frontend/src/hooks/useAirPlay.ts
@@ -24,10 +24,18 @@ export interface AirPlayState {
     showPicker: () => void;
 }
 
-export const useAirPlay = (player: VideoJsPlayer | null): AirPlayState => {
+export const useAirPlay = (
+    player: VideoJsPlayer | null,
+    onRouteChange?: (isWireless: boolean) => void
+): AirPlayState => {
     const [isAvailable, setIsAvailable] = useState(false);
     const [isActive, setIsActive] = useState(false);
     const videoRef = useRef<AirPlayVideoElement | null>(null);
+    const onRouteChangeRef = useRef(onRouteChange);
+
+    useEffect(() => {
+        onRouteChangeRef.current = onRouteChange;
+    }, [onRouteChange]);
 
     useEffect(() => {
         const video = player?.el()?.querySelector('video') ?? null;
@@ -40,12 +48,15 @@ export const useAirPlay = (player: VideoJsPlayer | null): AirPlayState => {
             setIsAvailable((event as PlaybackTargetAvailabilityEvent).availability === 'available');
         };
         const handleTargetChange = () => {
-            setIsActive(video.webkitCurrentPlaybackTargetIsWireless);
+            const isWireless = video.webkitCurrentPlaybackTargetIsWireless;
+            // Runs before React re-renders, so listeners still see the pre-swap position.
+            onRouteChangeRef.current?.(isWireless);
+            setIsActive(isWireless);
         };
 
         video.addEventListener('webkitplaybacktargetavailabilitychanged', handleAvailabilityChange);
         video.addEventListener('webkitcurrentplaybacktargetiswirelesschanged', handleTargetChange);
-        handleTargetChange();
+        setIsActive(video.webkitCurrentPlaybackTargetIsWireless);
 
         return () => {
             video.removeEventListener(

--- a/frontend/src/hooks/useAirPlay.ts
+++ b/frontend/src/hooks/useAirPlay.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+type VideoJsPlayer = ReturnType<typeof import('video.js').default>;
+
+interface AirPlayVideoElement extends HTMLVideoElement {
+    webkitShowPlaybackTargetPicker: () => void;
+    webkitCurrentPlaybackTargetIsWireless: boolean;
+}
+
+interface PlaybackTargetAvailabilityEvent extends Event {
+    availability: 'available' | 'not-available';
+}
+
+function supportsAirPlay(video: HTMLVideoElement | null): video is AirPlayVideoElement {
+    return (
+        !!video &&
+        typeof (video as AirPlayVideoElement).webkitShowPlaybackTargetPicker === 'function'
+    );
+}
+
+export interface AirPlayState {
+    isAvailable: boolean;
+    isActive: boolean;
+    showPicker: () => void;
+}
+
+export const useAirPlay = (player: VideoJsPlayer | null): AirPlayState => {
+    const [isAvailable, setIsAvailable] = useState(false);
+    const [isActive, setIsActive] = useState(false);
+    const videoRef = useRef<AirPlayVideoElement | null>(null);
+
+    useEffect(() => {
+        const video = player?.el()?.querySelector('video') ?? null;
+
+        if (!supportsAirPlay(video)) return;
+
+        videoRef.current = video;
+
+        const handleAvailabilityChange = (event: Event) => {
+            setIsAvailable((event as PlaybackTargetAvailabilityEvent).availability === 'available');
+        };
+        const handleTargetChange = () => {
+            setIsActive(video.webkitCurrentPlaybackTargetIsWireless);
+        };
+
+        video.addEventListener('webkitplaybacktargetavailabilitychanged', handleAvailabilityChange);
+        video.addEventListener('webkitcurrentplaybacktargetiswirelesschanged', handleTargetChange);
+        handleTargetChange();
+
+        return () => {
+            video.removeEventListener(
+                'webkitplaybacktargetavailabilitychanged',
+                handleAvailabilityChange
+            );
+            video.removeEventListener(
+                'webkitcurrentplaybacktargetiswirelesschanged',
+                handleTargetChange
+            );
+            videoRef.current = null;
+        };
+    }, [player]);
+
+    const showPicker = useCallback(() => {
+        videoRef.current?.webkitShowPlaybackTargetPicker();
+    }, []);
+
+    return { isAvailable, isActive, showPicker };
+};

--- a/frontend/src/pages/Player/PlayerControls.tsx
+++ b/frontend/src/pages/Player/PlayerControls.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
+    Airplay,
     Play,
     Pause,
     Volume2,
@@ -38,6 +39,7 @@ import { buildPlayerUrl } from '@/utils/playerUrl';
 import { isDesktopApp } from '@/utils/desktopApp';
 import { useTranslation } from 'react-i18next';
 import { usePlayerKeyboardControls } from '@/hooks/usePlayerKeyboardControls';
+import type { AirPlayState } from '@/hooks/useAirPlay';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { getLogoUrl, getPrimaryImageUrl, getTrickplayImageUrl } from '@pelagica/core';
 import { useReportPlaybackProgress } from '@pelagica/core';
@@ -102,6 +104,7 @@ interface PlayerControlsProps {
     onSubtitleTrackChange: (index: number | null) => void;
     isFullscreen: boolean;
     onFullscreenToggle?: () => void;
+    airPlay: AirPlayState;
     mediaSegments?: MediaSegmentDto[];
     previousItem?: BaseItemDto | null;
     nextItem?: BaseItemDto | null;
@@ -118,6 +121,7 @@ const PlayerControls = ({
     onSubtitleTrackChange,
     isFullscreen,
     onFullscreenToggle,
+    airPlay,
     mediaSegments,
     previousItem,
     nextItem,
@@ -923,6 +927,20 @@ const PlayerControls = ({
                                 <PictureInPicture2
                                     size={20}
                                     className={isPiP ? 'text-brand' : ''}
+                                />
+                            </Button>
+                        )}
+                        {airPlay.isAvailable && (
+                            <Button
+                                variant={'ghost'}
+                                size={'icon-lg'}
+                                onClick={airPlay.showPicker}
+                                className="cursor-pointer"
+                                title="AirPlay"
+                            >
+                                <Airplay
+                                    size={20}
+                                    className={airPlay.isActive ? 'text-brand' : ''}
                                 />
                             </Button>
                         )}

--- a/frontend/src/pages/Player/PlayerPage.tsx
+++ b/frontend/src/pages/Player/PlayerPage.tsx
@@ -37,6 +37,10 @@ import {
 const PLAYBACK_PROGRESS_REPORT_MIN_PLAYTIME_SECONDS = 5;
 const PLAYBACK_PROGRESS_REPORT_INTERVAL_MS = 5000;
 const FONT_ATTACHMENT_EXTENSION_PATTERN = /\.(ttf|otf|woff2?)$/i;
+const AIRPLAY_PLAYABLE_MIME_TYPES = new Set(['application/x-mpegURL', 'video/mp4']);
+// Budget for WebKit to re-take the route on a swapped source. Only applied while a swap is
+// in flight; a drop outside that window is a disconnect.
+const AIRPLAY_RELEASE_GRACE_MS = 15000;
 
 export type VideoJsPlayer = ReturnType<typeof import('video.js').default>;
 
@@ -99,6 +103,11 @@ const PlayerPage = () => {
         return null;
     }, [item, userConfiguration]);
 
+    const subtitleStreams = useMemo(
+        () => item?.MediaStreams?.filter((stream) => stream.Type === 'Subtitle') ?? [],
+        [item]
+    );
+
     const [audioTrackIndex, setAudioTrackIndex] = useState<number>(resolvedAudio.index);
     const [subtitleTrackIndex, setSubtitleTrackIndex] = useState<number | null>(
         resolvedSubtitleTrackIndex
@@ -107,7 +116,7 @@ const PlayerPage = () => {
     const progressReportingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
     const lastPositionRef = useRef<number>(0);
     const liveStreamIdRef = useRef<string | undefined>(undefined);
-    const pendingAudioSwitchSeekRef = useRef<number | null>(null);
+    const pendingSeekRef = useRef<number | null>(null);
     const [isFullscreen, setIsFullscreen] = useState(false);
     const {
         data: adjacentItems,
@@ -119,11 +128,95 @@ const PlayerPage = () => {
         isLoading: isLoadingMediaSegments,
         error: mediaSegmentsError,
     } = useMediaSegments(itemId);
+    // A torn-down element reports 0, which would drop the resume point the swap needs.
+    const capturePosition = useCallback(() => {
+        if (!player || player.isDisposed?.()) return;
+        const position = player.currentTime() ?? 0;
+        if (position > 0) pendingSeekRef.current = position;
+    }, [player]);
+
+    const [airPlayForcedHls, setAirPlayForcedHls] = useState(false);
+    // The route drops while a new source loads, then WebKit re-takes it. Reading the stream
+    // decision off airPlay.isActive would revert inside that gap and flip-flop for ever.
+    const [airPlayEngaged, setAirPlayEngaged] = useState(false);
+    const [airPlayPrefetch, setAirPlayPrefetch] = useState(false);
+    const swapInFlightRef = useRef(false);
+
+    const handleAirPlayRouteChange = useCallback(
+        (isWireless: boolean) => {
+            // Only the hand-off carries a position; by the drop the element reports 0.
+            if (!isWireless) return;
+            capturePosition();
+            setAirPlayEngaged(true);
+        },
+        [capturePosition]
+    );
+
+    const airPlay = useAirPlay(player, handleAirPlayRouteChange);
+    const { showPicker } = airPlay;
+
+    // Reverting at once folds the reload into the hand-back the viewer is already seeing.
+    useEffect(() => {
+        if (airPlay.isActive || !airPlayEngaged) return;
+
+        const releaseTimer = setTimeout(
+            () => {
+                capturePosition();
+                setAirPlayEngaged(false);
+            },
+            swapInFlightRef.current ? AIRPLAY_RELEASE_GRACE_MS : 0
+        );
+        return () => clearTimeout(releaseTimer);
+    }, [airPlay.isActive, airPlayEngaged, capturePosition]);
+
+    const burnInSubtitleStreamIndex = useMemo(() => {
+        if (!airPlayEngaged || subtitleTrackIndex === null) return undefined;
+        return subtitleStreams[subtitleTrackIndex]?.Index ?? undefined;
+    }, [airPlayEngaged, subtitleTrackIndex, subtitleStreams]);
+
+    // A swap is in flight until the new source loads: the only window the route drops in.
+    useEffect(() => {
+        if (!player) return;
+
+        swapInFlightRef.current = true;
+        const settle = () => {
+            swapInFlightRef.current = false;
+        };
+        const settleCap = setTimeout(settle, AIRPLAY_RELEASE_GRACE_MS);
+        player.one('loadeddata', settle);
+
+        return () => {
+            clearTimeout(settleCap);
+            player.off('loadeddata', settle);
+        };
+    }, [player, burnInSubtitleStreamIndex, airPlayForcedHls]);
+
+    // A swap waiting on a playback-info round-trip arrives after WebKit has given the route
+    // up, so opening the picker warms that request and leaves the swap a cache read.
+    const prospectiveBurnIn = useMemo(() => {
+        if (subtitleTrackIndex === null) return undefined;
+        return subtitleStreams[subtitleTrackIndex]?.Index ?? undefined;
+    }, [subtitleTrackIndex, subtitleStreams]);
+
+    usePlaybackInfo(itemId, getUserId() || undefined, audioTrackIndex, forceTranscode, {
+        forceHls: airPlayForcedHls,
+        burnInSubtitleStreamIndex: prospectiveBurnIn,
+        enabled: airPlayPrefetch && prospectiveBurnIn !== undefined,
+    });
+
+    const handleAirPlayPick = useCallback(() => {
+        setAirPlayPrefetch(true);
+        showPicker();
+    }, [showPicker]);
+
     const {
         data: playbackInfo,
         isLoading: isLoadingPlaybackInfo,
         error: playbackInfoError,
-    } = usePlaybackInfo(itemId, getUserId() || undefined, audioTrackIndex, forceTranscode);
+    } = usePlaybackInfo(itemId, getUserId() || undefined, audioTrackIndex, forceTranscode, {
+        forceHls: airPlayForcedHls,
+        burnInSubtitleStreamIndex,
+    });
 
     const playSessionId = playbackInfo?.playSessionId || '';
 
@@ -136,10 +229,21 @@ const PlayerPage = () => {
             mediaSourceId: playbackInfo.mediaSource.Id || undefined,
             container: playbackInfo.mediaSource.Container?.split(',')[0] || undefined,
             transcodingUrl: playbackInfo.mediaSource.TranscodingUrl,
+            burnInSubtitleStreamIndex,
         });
-    }, [itemId, playbackInfo, audioTrackIndex]);
+    }, [itemId, playbackInfo, audioTrackIndex, burnInSubtitleStreamIndex]);
 
-    const airPlay = useAirPlay(player);
+    useEffect(() => {
+        if (!airPlayEngaged) {
+            // eslint-disable-next-line react-hooks/set-state-in-effect
+            setAirPlayForcedHls(false);
+            return;
+        }
+
+        if (streamResult && !AIRPLAY_PLAYABLE_MIME_TYPES.has(streamResult.mimeType)) {
+            setAirPlayForcedHls(true);
+        }
+    }, [airPlayEngaged, streamResult]);
 
     const { reportProgress } = useReportPlaybackProgress();
     const { startPlayback } = usePlaybackStart();
@@ -180,7 +284,7 @@ const PlayerPage = () => {
         queueMicrotask(() => {
             hasUserSelectedAudioRef.current = false;
             hasUserSelectedSubtitleRef.current = false;
-            pendingAudioSwitchSeekRef.current = null;
+            pendingSeekRef.current = null;
             hasAttemptedTranscodeFallbackRef.current = false;
 
             setPlayer(null);
@@ -328,23 +432,23 @@ const PlayerPage = () => {
         [t]
     );
 
+    // Both re-source the element, so the position is captured before the swap resets it.
     const handleAudioTrackChange = (index: number) => {
-        pendingAudioSwitchSeekRef.current = player?.currentTime() || null;
+        capturePosition();
         hasUserSelectedAudioRef.current = true;
         setAudioTrackIndex(index);
     };
 
     const handleSubtitleTrackChange = (index: number | null) => {
+        capturePosition();
         hasUserSelectedSubtitleRef.current = true;
         setSubtitleTrackIndex(index);
     };
 
     const subtitleTracks = useMemo(() => {
-        if (!item?.Id || !item?.MediaStreams) return [];
+        if (!item?.Id) return [];
 
-        const subtitles = item.MediaStreams.filter((s) => s.Type === 'Subtitle');
-
-        return subtitles.map((subtitle): SubtitleTrack => {
+        return subtitleStreams.map((subtitle): SubtitleTrack => {
             const codec = subtitle.Codec?.toLowerCase();
             const isAss = codec === 'ass' || codec === 'ssa';
 
@@ -361,7 +465,7 @@ const PlayerPage = () => {
                 format: isAss ? 'ass' : 'vtt',
             };
         });
-    }, [item]);
+    }, [item, subtitleStreams]);
 
     const subtitleFonts = useMemo(() => {
         const attachments = playbackInfo?.mediaSource.MediaAttachments;
@@ -422,8 +526,10 @@ const PlayerPage = () => {
                 startTicks={item.UserData?.PlaybackPositionTicks || 0}
                 subtitles={subtitleTracks}
                 subtitleFonts={subtitleFonts}
-                pendingAudioSwitchSeekRef={pendingAudioSwitchSeekRef}
-                subtitleTrackIndex={subtitleTrackIndex}
+                pendingSeekRef={pendingSeekRef}
+                subtitleTrackIndex={
+                    burnInSubtitleStreamIndex === undefined ? subtitleTrackIndex : null
+                }
             />
             <PlayerControls
                 item={item}
@@ -434,7 +540,7 @@ const PlayerPage = () => {
                 onSubtitleTrackChange={handleSubtitleTrackChange}
                 isFullscreen={isFullscreen}
                 onFullscreenToggle={handleToggleFullscreen}
-                airPlay={airPlay}
+                airPlay={{ ...airPlay, isActive: airPlayEngaged, showPicker: handleAirPlayPick }}
                 mediaSegments={mediaSegments}
                 previousItem={adjacentItems?.previousItem}
                 nextItem={adjacentItems?.nextItem}

--- a/frontend/src/pages/Player/PlayerPage.tsx
+++ b/frontend/src/pages/Player/PlayerPage.tsx
@@ -24,6 +24,7 @@ import { getLastAudioLanguage, getLastSubtitleLanguage } from '@/utils/localstor
 import { useUserConfiguration } from '@pelagica/core';
 import { usePlayerItem } from '@pelagica/core';
 import { useMusicPlayback } from '@/hooks/useMusicPlayback';
+import { useAirPlay } from '@/hooks/useAirPlay';
 import { clearCodecCache } from '@pelagica/core';
 import {
     hideTrafficLights,
@@ -137,6 +138,8 @@ const PlayerPage = () => {
             transcodingUrl: playbackInfo.mediaSource.TranscodingUrl,
         });
     }, [itemId, playbackInfo, audioTrackIndex]);
+
+    const airPlay = useAirPlay(player);
 
     const { reportProgress } = useReportPlaybackProgress();
     const { startPlayback } = usePlaybackStart();
@@ -431,6 +434,7 @@ const PlayerPage = () => {
                 onSubtitleTrackChange={handleSubtitleTrackChange}
                 isFullscreen={isFullscreen}
                 onFullscreenToggle={handleToggleFullscreen}
+                airPlay={airPlay}
                 mediaSegments={mediaSegments}
                 previousItem={adjacentItems?.previousItem}
                 nextItem={adjacentItems?.nextItem}

--- a/frontend/src/pages/Player/VideoPlayer.tsx
+++ b/frontend/src/pages/Player/VideoPlayer.tsx
@@ -228,6 +228,7 @@ const VideoPlayer = ({
                 ref={videoRef}
                 className="video-js vjs-default-skin"
                 data-testid="video-player"
+                x-webkit-airplay="allow"
                 style={{ maxWidth: '100%', maxHeight: '100%', width: '100%', height: '100%' }}
             />
         </div>

--- a/frontend/src/pages/Player/VideoPlayer.tsx
+++ b/frontend/src/pages/Player/VideoPlayer.tsx
@@ -5,6 +5,10 @@ import JASSUB from 'jassub';
 
 type VideoJsPlayer = ReturnType<typeof videojs>;
 
+const SUPPORTS_AIRPLAY =
+    typeof document !== 'undefined' &&
+    'webkitShowPlaybackTargetPicker' in document.createElement('video');
+
 export interface SubtitleTrack {
     src: string;
     srclang: string;
@@ -60,7 +64,7 @@ const VideoPlayer = ({
             fluid: false,
             html5: {
                 nativeControlsForTouch: false,
-                hls: { overrideNative: true },
+                ...(SUPPORTS_AIRPLAY ? { vhs: { overrideNative: false } } : {}),
                 nativeTextTracks: false, // Force video.js to render text tracks
             },
         });

--- a/frontend/src/pages/Player/VideoPlayer.tsx
+++ b/frontend/src/pages/Player/VideoPlayer.tsx
@@ -110,7 +110,6 @@ const VideoPlayer = ({
 
         if (pendingSeekRef.current !== null) {
             seekTo = pendingSeekRef.current;
-            pendingSeekRef.current = null;
         } else if (!hasSeekedRef.current && startTicksRef.current > 0) {
             seekTo = startTicksRef.current / 10_000_000;
             hasSeekedRef.current = true;
@@ -122,6 +121,9 @@ const VideoPlayer = ({
         if (seekTo !== null) {
             const target = seekTo;
             const seekOnCanPlay = () => {
+                // Held until the seek lands: a second source change before canplay would
+                // otherwise find the position spent and restart from zero.
+                pendingSeekRef.current = null;
                 player.currentTime(target);
                 player.play()?.catch(console.error);
             };

--- a/frontend/src/pages/Player/VideoPlayer.tsx
+++ b/frontend/src/pages/Player/VideoPlayer.tsx
@@ -22,7 +22,7 @@ interface VideoPlayerProps {
     subtitleFonts?: string[];
     onReady?: (player: VideoJsPlayer) => void;
     onPlaybackError?: (error: MediaError | null) => void;
-    pendingAudioSwitchSeekRef: React.MutableRefObject<number | null>;
+    pendingSeekRef: React.MutableRefObject<number | null>;
     subtitleTrackIndex: number | null;
 }
 
@@ -35,7 +35,7 @@ const VideoPlayer = ({
     subtitleFonts,
     onReady,
     onPlaybackError,
-    pendingAudioSwitchSeekRef,
+    pendingSeekRef,
     subtitleTrackIndex,
 }: VideoPlayerProps) => {
     const videoRef = useRef<HTMLVideoElement | null>(null);
@@ -104,9 +104,9 @@ const VideoPlayer = ({
 
         let seekTo: number | null = null;
 
-        if (pendingAudioSwitchSeekRef.current !== null) {
-            seekTo = pendingAudioSwitchSeekRef.current;
-            pendingAudioSwitchSeekRef.current = null;
+        if (pendingSeekRef.current !== null) {
+            seekTo = pendingSeekRef.current;
+            pendingSeekRef.current = null;
         } else if (!hasSeekedRef.current && startTicksRef.current > 0) {
             seekTo = startTicksRef.current / 10_000_000;
             hasSeekedRef.current = true;
@@ -130,7 +130,7 @@ const VideoPlayer = ({
         }
 
         player.play()?.catch(console.error);
-    }, [src, srcType, pendingAudioSwitchSeekRef]);
+    }, [src, srcType, pendingSeekRef]);
 
     useEffect(() => {
         if (!playerRef.current) return;

--- a/frontend/src/pages/Player/VideoPlayer.tsx
+++ b/frontend/src/pages/Player/VideoPlayer.tsx
@@ -150,6 +150,10 @@ const VideoPlayer = ({
                 if (track) player.removeRemoteTextTrack(track);
             }
 
+            // Leaving them attached lets the tech re-enable a `default` track on the next
+            // source reload, drawing subtitles locally over a burnt-in stream.
+            if (activeIndex === null) return;
+
             if (subtitles && subtitles.length > 0) {
                 let addedCount = 0;
                 subtitles.forEach((subtitle, index) => {
@@ -162,7 +166,7 @@ const VideoPlayer = ({
                             src: subtitle.src,
                             srclang: subtitle.srclang,
                             label: subtitle.label,
-                            default: subtitle.default,
+                            default: index === activeIndex,
                         },
                         false // Don't add to DOM manually
                     );

--- a/packages/core/src/hooks/usePlaybackInfo.ts
+++ b/packages/core/src/hooks/usePlaybackInfo.ts
@@ -15,7 +15,11 @@ export interface PlaybackDecision {
     liveStreamId?: string;
 }
 
-function buildDeviceProfile(options?: { liveTvContainer?: boolean; excludeHevc?: boolean }) {
+function buildDeviceProfile(options?: {
+    liveTvContainer?: boolean;
+    excludeHevc?: boolean;
+    burnInSubtitles?: boolean;
+}) {
     const codecs = detectSupportedCodecs();
 
     const videoCodecs: string[] = [];
@@ -95,23 +99,44 @@ function buildDeviceProfile(options?: { liveTvContainer?: boolean; excludeHevc?:
         TranscodingProfiles: transcodingProfiles,
         ContainerProfiles: [],
         CodecProfiles: codecProfiles,
-        SubtitleProfiles: [
-            { Format: 'vtt', Method: 'External' as const },
-            { Format: 'srt', Method: 'External' as const },
-            { Format: 'ass', Method: 'External' as const },
-            { Format: 'ssa', Method: 'External' as const },
-        ],
+        SubtitleProfiles: options?.burnInSubtitles
+            ? []
+            : [
+                  { Format: 'vtt', Method: 'External' as const },
+                  { Format: 'srt', Method: 'External' as const },
+                  { Format: 'ass', Method: 'External' as const },
+                  { Format: 'ssa', Method: 'External' as const },
+              ],
     };
+}
+
+export interface PlaybackOptions {
+    forceHls?: boolean;
+    burnInSubtitleStreamIndex?: number;
+    /** Set false to hold the request back, e.g. to warm a variant only once it is wanted. */
+    enabled?: boolean;
 }
 
 export function usePlaybackInfo(
     itemId: string | null | undefined,
     userId: string | undefined,
     audioStreamIndex?: number,
-    forceTranscode?: boolean
+    forceTranscode?: boolean,
+    options?: PlaybackOptions
 ) {
+    const burnInSubtitleStreamIndex = options?.burnInSubtitleStreamIndex;
+    const skipDirectPlay =
+        !!forceTranscode || !!options?.forceHls || burnInSubtitleStreamIndex !== undefined;
+
     return useQuery<PlaybackDecision>({
-        queryKey: ['playbackInfo', itemId, audioStreamIndex, forceTranscode],
+        queryKey: [
+            'playbackInfo',
+            itemId,
+            audioStreamIndex,
+            forceTranscode,
+            options?.forceHls,
+            burnInSubtitleStreamIndex,
+        ],
         queryFn: async (): Promise<PlaybackDecision> => {
             const api = getApi();
             const mediaInfoApi = getMediaInfoApi(api);
@@ -121,13 +146,17 @@ export function usePlaybackInfo(
                 userId,
                 maxStreamingBitrate: 80_000_000,
                 audioStreamIndex,
-                enableDirectPlay: !forceTranscode,
-                enableDirectStream: !forceTranscode,
+                subtitleStreamIndex: burnInSubtitleStreamIndex,
+                enableDirectPlay: !skipDirectPlay,
+                enableDirectStream: !skipDirectPlay,
                 enableTranscoding: true,
                 allowVideoStreamCopy: !forceTranscode,
                 allowAudioStreamCopy: true,
                 playbackInfoDto: {
-                    DeviceProfile: buildDeviceProfile({ excludeHevc: forceTranscode }),
+                    DeviceProfile: buildDeviceProfile({
+                        excludeHevc: forceTranscode,
+                        burnInSubtitles: burnInSubtitleStreamIndex !== undefined,
+                    }),
                 },
             });
 
@@ -150,12 +179,14 @@ export function usePlaybackInfo(
                         PlaySessionId: playSessionId,
                         ItemId: itemId,
                         AudioStreamIndex: audioStreamIndex,
+                        SubtitleStreamIndex: burnInSubtitleStreamIndex,
                         MaxStreamingBitrate: 80_000_000,
-                        EnableDirectPlay: !forceTranscode,
-                        EnableDirectStream: !forceTranscode,
+                        EnableDirectPlay: !skipDirectPlay,
+                        EnableDirectStream: !skipDirectPlay,
                         DeviceProfile: buildDeviceProfile({
                             liveTvContainer: true,
                             excludeHevc: forceTranscode,
+                            burnInSubtitles: burnInSubtitleStreamIndex !== undefined,
                         }),
                     },
                 });
@@ -177,7 +208,7 @@ export function usePlaybackInfo(
 
             return { playMethod, mediaSource: source, playSessionId, liveStreamId };
         },
-        enabled: !!itemId,
+        enabled: !!itemId && options?.enabled !== false,
         staleTime: 30_000,
         refetchOnWindowFocus: false,
         refetchOnReconnect: false,

--- a/packages/core/src/hooks/usePlaybackInfo.ts
+++ b/packages/core/src/hooks/usePlaybackInfo.ts
@@ -209,7 +209,9 @@ export function usePlaybackInfo(
             return { playMethod, mediaSource: source, playSessionId, liveStreamId };
         },
         enabled: !!itemId && options?.enabled !== false,
-        staleTime: 30_000,
+        // Returning to a variant used earlier in the same playback must come from cache: a
+        // refetch hands back a fresh PlaySessionId, which changes the url and reloads the video.
+        staleTime: 5 * 60_000,
         refetchOnWindowFocus: false,
         refetchOnReconnect: false,
         ...getRetryConfig(),

--- a/packages/core/src/utils/jellyfinUrls.ts
+++ b/packages/core/src/utils/jellyfinUrls.ts
@@ -205,6 +205,7 @@ export function getVideoStreamUrl(
         playSessionId?: string;
         audioStreamIndex?: number;
         mediaSourceId?: string;
+        burnInSubtitleStreamIndex?: number;
     }
 ) {
     try {
@@ -232,6 +233,13 @@ export function getVideoStreamUrl(
             url.searchParams.append('PlaySessionId', options.playSessionId);
         if (options.audioStreamIndex !== undefined)
             url.searchParams.append('AudioStreamIndex', options.audioStreamIndex.toString());
+        if (options.burnInSubtitleStreamIndex !== undefined) {
+            url.searchParams.append(
+                'SubtitleStreamIndex',
+                options.burnInSubtitleStreamIndex.toString()
+            );
+            url.searchParams.append('SubtitleMethod', 'Encode');
+        }
 
         return url.toString();
     } catch {
@@ -291,6 +299,7 @@ export function getPlaybackStreamUrl(
         mediaSourceId?: string;
         container?: string;
         transcodingUrl?: string | null;
+        burnInSubtitleStreamIndex?: number;
     }
 ): PlaybackStreamResult {
     const creds = resolveCredentials();
@@ -318,6 +327,13 @@ export function getPlaybackStreamUrl(
         if (options.audioStreamIndex !== undefined) {
             url.searchParams.set('AudioStreamIndex', options.audioStreamIndex.toString());
         }
+        if (options.burnInSubtitleStreamIndex !== undefined) {
+            url.searchParams.set(
+                'SubtitleStreamIndex',
+                options.burnInSubtitleStreamIndex.toString()
+            );
+            url.searchParams.set('SubtitleMethod', 'Encode');
+        }
         return {
             url: url.toString(),
             mimeType: 'application/x-mpegURL',
@@ -329,6 +345,7 @@ export function getPlaybackStreamUrl(
             audioStreamIndex: options.audioStreamIndex,
             playSessionId: options.playSessionId,
             mediaSourceId: options.mediaSourceId,
+            burnInSubtitleStreamIndex: options.burnInSubtitleStreamIndex,
         }),
         mimeType: 'application/x-mpegURL',
     };


### PR DESCRIPTION
- added an AirPlay button to the video controls (Safari/MacOS desktop app)
- swap to an AirPlay-compatible stream once a route is taken
- burn subtitles for airplay. Switching subtitles or audio switches the airplay stream
- hold the pending seek until it is applied, so two source changes in quick succession do not restart playback

I tested the functionality against my TV. It seems to work well, but maybe my testing wasn't perfect. 

One thing to keep in mind that in order for the subtitles to work it requests them burned in from Jellyfin, so if you don't have a powerful enough server this might not work as well as expected.