### PR TITLE
Fix WebOS resume and support magic remote pointer

### DIFF
--- a/packages/tv-frontend/src/components/FocusableButton.tsx
+++ b/packages/tv-frontend/src/components/FocusableButton.tsx
@@ -22,6 +22,7 @@ const FocusableButton = ({
 }) => {
     const { ref, focused, focusSelf } = useFocusable<object, HTMLButtonElement>({
         focusKey,
+        focusOnHover: true,
         onEnterPress: () => ref.current?.click(),
     });
     const isLayerActive = useLayerActive();

--- a/packages/tv-frontend/src/components/FocusableCard.tsx
+++ b/packages/tv-frontend/src/components/FocusableCard.tsx
@@ -28,6 +28,7 @@ const FocusableCard = ({
     const cardFocusKey = `${layerId}:${rowIdentity}:${to}`;
     const { ref, focused, focusSelf } = useLayerFocusable<object, HTMLAnchorElement>({
         focusKey: cardFocusKey,
+        focusOnHover: true,
         onEnterPress: () => ref.current?.click(),
         onFocus: () => rememberFocusedKey(pathname, cardFocusKey),
     });

--- a/packages/tv-frontend/src/components/FocusableField.tsx
+++ b/packages/tv-frontend/src/components/FocusableField.tsx
@@ -17,6 +17,7 @@ const FocusableField = ({
 }) => {
     const { ref, focused, focusSelf } = useFocusable<object, HTMLInputElement>({
         focusKey,
+        focusOnHover: true,
         onEnterPress: () => ref.current?.focus(),
         onBlur: () => ref.current?.blur(),
     });

--- a/packages/tv-frontend/src/components/FocusableNavLink.tsx
+++ b/packages/tv-frontend/src/components/FocusableNavLink.tsx
@@ -26,6 +26,7 @@ const FocusableNavLink = ({
     const location = useLocation();
     const { ref, focused, focusSelf } = useLayerFocusable<object, HTMLAnchorElement>({
         focusKey,
+        focusOnHover: true,
         onEnterPress: () => ref.current?.click(),
     });
 

--- a/packages/tv-frontend/src/components/FocusablePaginationLink.tsx
+++ b/packages/tv-frontend/src/components/FocusablePaginationLink.tsx
@@ -19,6 +19,7 @@ const FocusablePaginationLink = ({
     text?: string;
 }) => {
     const { ref, focused } = useFocusable<object, HTMLAnchorElement>({
+        focusOnHover: true,
         onEnterPress: () => ref.current?.click(),
     });
 

--- a/packages/tv-frontend/src/components/player/PlayerControls.tsx
+++ b/packages/tv-frontend/src/components/player/PlayerControls.tsx
@@ -163,8 +163,16 @@ const PlayerControls = forwardRef<PlayerControlsHandle, PlayerControlsProps>(
                 resetHideTimeout();
             }
 
+            function handlePointerActivity() {
+                resetHideTimeout();
+            }
+
             window.addEventListener('keydown', handleKeyDown);
-            return () => window.removeEventListener('keydown', handleKeyDown);
+            window.addEventListener('mousemove', handlePointerActivity);
+            return () => {
+                window.removeEventListener('keydown', handleKeyDown);
+                window.removeEventListener('mousemove', handlePointerActivity);
+            };
         }, [resetHideTimeout, showControls, playPauseFocusKey]);
 
         useImperativeHandle(
@@ -685,6 +693,7 @@ function TrackOption({
     onClick: () => void;
 }) {
     const { ref, focused, focusSelf } = useLayerFocusable<object, HTMLButtonElement>({
+        focusOnHover: true,
         onEnterPress: () => ref.current?.click(),
     });
 

--- a/packages/tv-frontend/src/components/player/VideoPlayer.tsx
+++ b/packages/tv-frontend/src/components/player/VideoPlayer.tsx
@@ -97,15 +97,10 @@ const VideoPlayer = ({
         };
     }, [onReady]);
 
+    const startTicksRef = useRef(startTicks);
+
     useEffect(() => {
-        if (!playerRef.current) return;
-        if (!startTicks || startTicks <= 0) return;
-        if (hasSeekedRef.current) return;
-
-        const seconds = startTicks / 10_000_000;
-
-        playerRef.current.currentTime(seconds);
-        hasSeekedRef.current = true;
+        startTicksRef.current = startTicks;
     }, [startTicks]);
 
     useEffect(() => {
@@ -124,15 +119,13 @@ const VideoPlayer = ({
         if (pendingAudioSwitchSeekRef.current !== null) {
             seekTo = pendingAudioSwitchSeekRef.current;
             pendingAudioSwitchSeekRef.current = null;
+        } else if (!hasSeekedRef.current && startTicksRef.current > 0) {
+            seekTo = startTicksRef.current / 10_000_000;
+            hasSeekedRef.current = true;
         }
 
         player.pause();
         player.src({ src, type: srcType });
-        player.load();
-
-        if (seekTo !== null) {
-            player.currentTime(seekTo);
-        }
 
         const clearStallTimeout = () => {
             if (stallTimeoutRef.current) {
@@ -149,9 +142,23 @@ const VideoPlayer = ({
 
         player.one(['playing', 'timeupdate'], clearStallTimeout);
 
-        player.play()?.catch(console.error);
+        let seekOnCanPlay: (() => void) | null = null;
+
+        if (seekTo !== null) {
+            const target = seekTo;
+
+            seekOnCanPlay = () => {
+                player.currentTime(target);
+                player.play()?.catch(console.error);
+            };
+
+            player.one('canplay', seekOnCanPlay);
+        } else {
+            player.play()?.catch(console.error);
+        }
 
         return () => {
+            if (seekOnCanPlay) player.off('canplay', seekOnCanPlay);
             player.off(['playing', 'timeupdate'], clearStallTimeout);
             clearStallTimeout();
         };

--- a/packages/tv-frontend/src/router/useLayerFocusable.ts
+++ b/packages/tv-frontend/src/router/useLayerFocusable.ts
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useFocusable } from '@noriginmedia/norigin-spatial-navigation';
 import type {
     UseFocusableConfig,
@@ -5,16 +6,32 @@ import type {
 } from '@noriginmedia/norigin-spatial-navigation';
 import { useLayerActive } from './hooks';
 
+export interface LayerFocusableConfig<P> extends UseFocusableConfig<P> {
+    focusOnHover?: boolean;
+}
+
 /**
  * Wraps norigin's useFocusable so elements in a hidden (non-top) layer stop participating in spatial navigation.
  */
-export function useLayerFocusable<P, E = HTMLElement>(
-    config?: UseFocusableConfig<P>
+export function useLayerFocusable<P, E extends HTMLElement = HTMLElement>(
+    config?: LayerFocusableConfig<P>
 ): UseFocusableResult<E> {
     const isLayerActive = useLayerActive();
+    const focusable = (config?.focusable ?? true) && isLayerActive;
+    const focusOnHover = config?.focusOnHover ?? false;
 
-    return useFocusable<P, E>({
-        ...config,
-        focusable: (config?.focusable ?? true) && isLayerActive,
-    });
+    const result = useFocusable<P, E>({ ...config, focusable });
+    const { ref, focusSelf } = result;
+
+    useEffect(() => {
+        const element = ref.current;
+        if (!element || !focusable || !focusOnHover) return;
+
+        const handleMouseEnter = () => focusSelf();
+
+        element.addEventListener('mouseenter', handleMouseEnter);
+        return () => element.removeEventListener('mouseenter', handleMouseEnter);
+    }, [ref, focusable, focusOnHover, focusSelf]);
+
+    return result;
 }

--- a/packages/tv-frontend/src/routes/SeriesDetail.tsx
+++ b/packages/tv-frontend/src/routes/SeriesDetail.tsx
@@ -39,6 +39,7 @@ const EpisodeCard = memo(function EpisodeCard({
     const navigate = useNavigate();
     const { t } = useTranslation('item');
     const { ref, focused, focusSelf } = useFocusable<object, HTMLButtonElement>({
+        focusOnHover: true,
         onEnterPress: () => ref.current?.click(),
     });
 

--- a/packages/tv-frontend/src/routes/Settings.tsx
+++ b/packages/tv-frontend/src/routes/Settings.tsx
@@ -46,7 +46,9 @@ const Settings = () => {
     const serverUrl = getServerUrl();
     const { data: user, isLoading } = useCurrentUser();
     const navigate = useNavigate();
-    const { ref: aboutRef, focused: aboutFocused } = useFocusable<object, HTMLDivElement>({});
+    const { ref: aboutRef, focused: aboutFocused } = useFocusable<object, HTMLDivElement>({
+        focusOnHover: true,
+    });
     useScrollIntoViewOnFocus(aboutRef, aboutFocused);
 
     return (


### PR DESCRIPTION
- applied the same fix for subtitle desync on the webOS build.
- fixed a resume issue where if you played an item that already started it would play for 5-10 seconds and then go back to the resume point once causing subtitles to be out of sync
- made magic remote pointer work with the items in the app
- fixed an issue where the magic remote pointer didn't reveal the player buttons while playing a tv show/movie

I've tested all the changes on my LG TV (wasn't fun). With the changes the webOS build is a lot more usable. 

Let me know if you want any code changes :)