### PR TITLE
Serve the app under a configurable base path (/pelagica)

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -124,9 +124,9 @@ jobs:
           
           docker buildx imagetools create \
             -t ${{ env.DOCKER_IMAGE }}:${{ github.ref_name }}${{ matrix.variant.suffix }} \
-            -t ${{ env.DOCKER_IMAGE }}:latest-${{ matrix.variant.suffix }} \
+            -t ${{ env.DOCKER_IMAGE }}:latest${{ matrix.variant.suffix }} \
             "${refs[@]}"
 
       - name: Inspect manifest
         run: |
-          docker buildx imagetools inspect ${{ env.DOCKER_IMAGE }}:${{ github.ref_name }}${{ matrix.variant.name }}
+          docker buildx imagetools inspect ${{ env.DOCKER_IMAGE }}:${{ github.ref_name }}${{ matrix.variant.suffix }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -22,10 +22,17 @@ jobs:
         platform:
           - linux/amd64
           - linux/arm64
+        variant:
+          - name: default
+            suffix: ''
+            base_path: ''
+          - name: basepath
+            suffix: '-basepath'
+            base_path: '/pelagica'
 
     runs-on: ${{ matrix.platform == 'linux/amd64' && 'ubuntu-latest' || matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' }}
 
-    name: Build Docker image for ${{ matrix.platform }}
+    name: Build Docker ${{ matrix.variant.name }} image for ${{ matrix.platform }}
 
     steps:
       - name: Set PLATFORM_PAIR
@@ -58,14 +65,15 @@ jobs:
           push: true
           platforms: ${{ matrix.platform }}
           tags: |
-            ${{ env.DOCKER_IMAGE }}:${{ github.ref_name }}-${{ env.PLATFORM_PAIR }}
-            ${{ env.DOCKER_IMAGE }}:latest-${{ env.PLATFORM_PAIR }}
+            ${{ env.DOCKER_IMAGE }}:${{ github.ref_name }}${{ matrix.variant.suffix }}-${{ env.PLATFORM_PAIR }}
+            ${{ env.DOCKER_IMAGE }}:latest${{ matrix.variant.suffix }}-${{ env.PLATFORM_PAIR }}
           build-args: |
             APP_VERSION=${{ github.ref_name }}
             COLLECTOR_PING_TOKEN=${{ secrets.STATS_TOKEN }}
+            BASE_PATH=${{ matrix.variant.base_path }}
           outputs: type=registry
-          cache-from: type=gha,scope=${{ github.repository }}-${{ github.ref_name }}-${{ env.PLATFORM_PAIR }}
-          cache-to: type=gha,scope=${{ github.repository }}-${{ github.ref_name }}-${{ env.PLATFORM_PAIR }}
+          cache-from: type=gha,scope=${{ github.repository }}-${{ github.ref_name }}-${{ matrix.variant.name }}-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,scope=${{ github.repository }}-${{ github.ref_name }}-${{ matrix.variant.name }}-${{ env.PLATFORM_PAIR }}
 
       - name: Export digest
         run: |
@@ -75,16 +83,23 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v6
         with:
-          name: digests-${{ env.PLATFORM_PAIR }}
+          name: digests-${{ matrix.variant.name }}-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
 
   merge:
-    name: Create Multi-Arch Manifest
+    name: Create ${{ matrix.variant.name }} Multi-Arch Manifest
     runs-on: ubuntu-latest
     needs: build
-
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+          - name: default
+            suffix: ''
+          - name: basepath
+            suffix: '-basepath'
     steps:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -96,7 +111,7 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           path: /tmp/digests
-          pattern: digests-*
+          pattern: digests-${{ matrix.variant.name }}-*
           merge-multiple: true
 
       - name: Create multi-arch manifest
@@ -108,10 +123,10 @@ jobs:
           done
           
           docker buildx imagetools create \
-            -t ${{ env.DOCKER_IMAGE }}:${{ github.ref_name }} \
-            -t ${{ env.DOCKER_IMAGE }}:latest \
+            -t ${{ env.DOCKER_IMAGE }}:${{ github.ref_name }}${{ matrix.variant.suffix }} \
+            -t ${{ env.DOCKER_IMAGE }}:latest-${{ matrix.variant.suffix }} \
             "${refs[@]}"
 
       - name: Inspect manifest
         run: |
-          docker buildx imagetools inspect ${{ env.DOCKER_IMAGE }}:${{ github.ref_name }}
+          docker buildx imagetools inspect ${{ env.DOCKER_IMAGE }}:${{ github.ref_name }}${{ matrix.variant.name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ RUN npm install -g pnpm \
 
 COPY packages/core packages/core
 COPY frontend frontend
-RUN pnpm --filter pelagica run build
+ARG BASE_PATH=
+RUN BASE_PATH=$BASE_PATH pnpm --filter pelagica run build
 
 
 # Stage 2: Build backend
@@ -45,7 +46,8 @@ ARG COLLECTOR_PING_TOKEN
 RUN apk add --no-cache ca-certificates tzdata
 
 # frontend
-COPY --from=frontend-builder /app/frontend/dist /usr/share/nginx/html
+ARG BASE_PATH=
+COPY --from=frontend-builder /app/frontend/dist /usr/share/nginx/html${BASE_PATH}
 
 # backend
 COPY --from=backend-builder /backend/server /server
@@ -53,6 +55,9 @@ COPY --from=backend-builder /backend/default.theme.json /default.theme.json
 
 # nginx config
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+RUN sed -i "s|__BASE_PATH__|${BASE_PATH}|g" \
+        /etc/nginx/conf.d/default.conf \
+        /usr/share/nginx/html${BASE_PATH}/manifest.webmanifest
 
 # config directory (volume-friendly)
 RUN mkdir -p /config

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,8 @@ RUN apk add --no-cache ca-certificates tzdata
 
 # frontend
 ARG BASE_PATH=
+# drop the nginx default page so a base-path build serves nothing at /
+RUN rm -f /usr/share/nginx/html/index.html /usr/share/nginx/html/50x.html
 COPY --from=frontend-builder /app/frontend/dist /usr/share/nginx/html${BASE_PATH}
 
 # backend

--- a/frontend/public/manifest.webmanifest
+++ b/frontend/public/manifest.webmanifest
@@ -4,15 +4,15 @@
     "description": "Watch Movies and TV Shows from your Jellyfin server.",
     "display": "standalone",
     "categories": ["entertainment", "video", "movies", "tv"],
-    "start_url": "/",
+    "start_url": "__BASE_PATH__/",
     "icons": [
         {
-            "src": "/favicons/favicon-192x192.png",
+            "src": "__BASE_PATH__/favicons/favicon-192x192.png",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "/favicons/favicon-512x512.png",
+            "src": "__BASE_PATH__/favicons/favicon-512x512.png",
             "sizes": "512x512",
             "type": "image/png"
         }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import { ScrollToTop } from './components/ScrollToTop.tsx';
 import { DesktopDragRegion } from './components/DesktopDragRegion.tsx';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from './components/theme-provider.tsx';
+import { BASE_PATH } from '@pelagica/core';
 
 const HomePage = lazy(() => import('./pages/Home/HomePage.tsx'));
 const LoginPage = lazy(() => import('./pages/Login/LoginPage.tsx'));
@@ -44,7 +45,7 @@ export default function App() {
             <ThemeProvider>
                 <MusicPlaybackProvider>
                     <SearchProvider>
-                        <BrowserRouter>
+                        <BrowserRouter basename={BASE_PATH || undefined}>
                             <AdminItemDialogsProvider>
                                 <SeerrItemDialogProvider>
                                     <ScrollToTop />

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -79,6 +79,7 @@ import { useTheme } from '@/components/theme-provider';
 import { getEffectiveTheme } from '@/utils/effectiveTheme';
 import { logout } from '@pelagica/core';
 import { getUserProfileImageUrl } from '@pelagica/core';
+import { withBasePath } from '@pelagica/core';
 import { SUPPORTED_LIBRARY_COLLECTION_TYPES } from '../utils/itemTypes';
 import { DynamicIcon, type IconName } from 'lucide-react/dynamic';
 import { useTranslation } from 'react-i18next';
@@ -686,7 +687,7 @@ const TopBar = ({ overlay = false }: { overlay?: boolean }) => {
         return onWindowMaximiseChange(setIsMaximised);
     }, [isWindowsOrLinux]);
 
-    const defaultLogo = effectiveTheme === 'dark' ? '/logo.svg' : '/logo-dark.svg';
+    const defaultLogo = withBasePath(effectiveTheme === 'dark' ? '/logo.svg' : '/logo-dark.svg');
     const configuredLogo =
         effectiveTheme === 'dark' ? config?.logoDarkUrl || '' : config?.logoLightUrl || '';
     const logoSrc = configuredLogo || defaultLogo;

--- a/frontend/src/hooks/api/usePelagicaPluginStatus.ts
+++ b/frontend/src/hooks/api/usePelagicaPluginStatus.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
-import { getServerUrl } from '@pelagica/core';
+import { getServerUrl, withBasePath } from '@pelagica/core';
 import type { AppConfig } from '@pelagica/core';
 import {
     fetchPluginConfig,
@@ -28,7 +28,9 @@ async function resolvePluginStatus(serverUrl: string): Promise<PelagicaPluginSta
 
 async function fetchLegacyConfig(serverUrl: string): Promise<Record<string, unknown> | null> {
     try {
-        const response = await fetch('/api/config?jellyfin_url=' + encodeURIComponent(serverUrl));
+        const response = await fetch(
+            withBasePath('/api/config?jellyfin_url=' + encodeURIComponent(serverUrl))
+        );
         if (!response.ok) return null;
         return await response.json();
     } catch {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,8 +3,11 @@ import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const basePath = (process.env.BASE_PATH ?? '').replace(/\/+$/, '');
+
 // https://vite.dev/config/
 export default defineConfig({
+    base: `${basePath}/`,
     plugins: [react(), tailwindcss()],
     resolve: {
         alias: {
@@ -15,10 +18,10 @@ export default defineConfig({
         port: 3000,
         allowedHosts: ['mbjan.local'],
         proxy: {
-            '/api': {
+            [`${basePath}/api`]: {
                 target: 'http://localhost:4321/api',
                 changeOrigin: true,
-                rewrite: (path) => path.replace(/^\/api/, ''), // remove /api prefix when forwarding to backend
+                rewrite: (path) => path.replace(new RegExp(`^${basePath}/api`), ''), // remove /api prefix when forwarding to backend
             },
         },
     },

--- a/nginx.conf
+++ b/nginx.conf
@@ -31,8 +31,8 @@ server {
     }
 
     # Go backend
-    location /api/ {
-        proxy_pass http://127.0.0.1:4321;
+    location __BASE_PATH__/api/ {
+        proxy_pass http://127.0.0.1:4321/api/;
         proxy_http_version 1.1;
 
         proxy_set_header Host $host;
@@ -43,8 +43,8 @@ server {
     }
 
     # Redirect /api to /api/
-    location = /api {
-        return 301 /api/;
+    location = __BASE_PATH__/api {
+        return 301 __BASE_PATH__/api/;
     }
 
     # Health check endpoint
@@ -55,8 +55,8 @@ server {
     }
 
     # SPA routing
-    location / {
-        try_files $uri $uri/ /index.html;
+    location __BASE_PATH__/ {
+        try_files $uri $uri/ __BASE_PATH__/index.html;
         add_header Cache-Control "no-cache, no-store, must-revalidate";
     }
 }

--- a/packages/core/src/api/seerr/details.ts
+++ b/packages/core/src/api/seerr/details.ts
@@ -1,3 +1,4 @@
+import { withBasePath } from '../../utils/basePath';
 import { getServerUrl } from '../../utils/localstorageCredentials';
 import type {
     SeerrItemDetails,
@@ -11,7 +12,9 @@ export async function getSeerrItemDetails(
     id: number
 ): Promise<SeerrItemDetails> {
     const response = await fetch(
-        `/api/seerr/${mediaType}/${id}?jellyfin_url=${encodeURIComponent(getServerUrl() || '')}`
+        withBasePath(
+            `/api/seerr/${mediaType}/${id}?jellyfin_url=${encodeURIComponent(getServerUrl() || '')}`
+        )
     );
     if (!response.ok) {
         throw new Error(`API request failed: ${response.statusText}`);

--- a/packages/core/src/api/seerr/discover.ts
+++ b/packages/core/src/api/seerr/discover.ts
@@ -1,3 +1,4 @@
+import { withBasePath } from '../../utils/basePath';
 import { getServerUrl } from '../../utils/localstorageCredentials';
 import type {
     SeerrMovieRecommendationsResponse,
@@ -8,7 +9,7 @@ import type {
 
 async function fetchSeerr<T>(path: string): Promise<T> {
     const response = await fetch(
-        `${path}?jellyfin_url=${encodeURIComponent(getServerUrl() || '')}`
+        withBasePath(`${path}?jellyfin_url=${encodeURIComponent(getServerUrl() || '')}`)
     );
     if (!response.ok) {
         throw new Error(`API request failed: ${response.statusText}`);

--- a/packages/core/src/api/seerr/login.ts
+++ b/packages/core/src/api/seerr/login.ts
@@ -1,9 +1,13 @@
+import { withBasePath } from '../../utils/basePath';
+
 export async function loginToSeerr(
     server: string,
     username: string,
     password: string
 ): Promise<boolean> {
-    const response = await fetch('/api/seerr/login?jellyfin_url=' + encodeURIComponent(server), {
+    const response = await fetch(
+        withBasePath('/api/seerr/login?jellyfin_url=' + encodeURIComponent(server)),
+        {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',

--- a/packages/core/src/api/seerr/logout.ts
+++ b/packages/core/src/api/seerr/logout.ts
@@ -1,10 +1,13 @@
+import { withBasePath } from '../../utils/basePath';
 import { getServerUrl } from '../../utils/localstorageCredentials';
 
 export async function logoutFromSeerr(): Promise<void> {
     try {
         const server = getServerUrl();
         await fetch(
-            '/api/seerr/logout' + (server ? '?jellyfin_url=' + encodeURIComponent(server) : ''),
+            withBasePath(
+                '/api/seerr/logout' + (server ? '?jellyfin_url=' + encodeURIComponent(server) : '')
+            ),
             { method: 'POST', credentials: 'include' }
         );
     } catch (e) {

--- a/packages/core/src/api/seerr/person.ts
+++ b/packages/core/src/api/seerr/person.ts
@@ -1,3 +1,4 @@
+import { withBasePath } from '../../utils/basePath';
 import { getServerUrl } from '../../utils/localstorageCredentials';
 import type { SeerrPersonCombinedCreditsResponse } from './types';
 
@@ -5,7 +6,9 @@ export async function getSeerrPersonCombinedCredits(
     personId: string
 ): Promise<SeerrPersonCombinedCreditsResponse> {
     const response = await fetch(
-        `/api/seerr/person/${personId}/combined_credits?jellyfin_url=${encodeURIComponent(getServerUrl() || '')}`
+        withBasePath(
+            `/api/seerr/person/${personId}/combined_credits?jellyfin_url=${encodeURIComponent(getServerUrl() || '')}`
+        )
     );
     if (!response.ok) {
         throw new Error(`API request failed: ${response.statusText}`);

--- a/packages/core/src/api/seerr/recommendations.ts
+++ b/packages/core/src/api/seerr/recommendations.ts
@@ -1,3 +1,4 @@
+import { withBasePath } from '../../utils/basePath';
 import { getServerUrl } from '../../utils/localstorageCredentials';
 import type {
     SeerrMediaType,
@@ -10,7 +11,9 @@ export async function getSeerrMovieRecommendations(
     tmdbId: string
 ): Promise<SeerrRecommendationItem[]> {
     const response = await fetch(
-        `/api/seerr/movie/${tmdbId}/recommendations?jellyfin_url=${encodeURIComponent(getServerUrl() || '')}`
+        withBasePath(
+            `/api/seerr/movie/${tmdbId}/recommendations?jellyfin_url=${encodeURIComponent(getServerUrl() || '')}`
+        )
     );
     if (!response.ok) {
         throw new Error(`API request failed: ${response.statusText}`);
@@ -27,7 +30,9 @@ export async function getSeerrMovieRecommendations(
 
 export async function getSeerrTvRecommendations(tvId: string): Promise<SeerrRecommendationItem[]> {
     const response = await fetch(
-        `/api/seerr/tv/${tvId}/recommendations?jellyfin_url=${encodeURIComponent(getServerUrl() || '')}`
+        withBasePath(
+            `/api/seerr/tv/${tvId}/recommendations?jellyfin_url=${encodeURIComponent(getServerUrl() || '')}`
+        )
     );
     if (!response.ok) {
         throw new Error(`API request failed: ${response.statusText}`);

--- a/packages/core/src/api/seerr/request.ts
+++ b/packages/core/src/api/seerr/request.ts
@@ -1,9 +1,10 @@
+import { withBasePath } from '../../utils/basePath';
 import { getServerUrl } from '../../utils/localstorageCredentials';
 import type { SeerrRequestPayload } from './types';
 
 export async function requestSeerrItem(payload: SeerrRequestPayload): Promise<void> {
     const response = await fetch(
-        `/api/seerr/request?jellyfin_url=${encodeURIComponent(getServerUrl() || '')}`,
+        withBasePath(`/api/seerr/request?jellyfin_url=${encodeURIComponent(getServerUrl() || '')}`),
         {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },

--- a/packages/core/src/api/seerr/search.ts
+++ b/packages/core/src/api/seerr/search.ts
@@ -1,9 +1,12 @@
+import { withBasePath } from '../../utils/basePath';
 import { getServerUrl } from '../../utils/localstorageCredentials';
 import type { SeerrSearchResponse, SeerrSearchResultItem } from './types';
 
 export async function searchSeerr(query: string): Promise<SeerrSearchResultItem[]> {
     const response = await fetch(
-        `/api/seerr/search?query=${encodeURIComponent(query)}&jellyfin_url=${encodeURIComponent(getServerUrl() || '')}`
+        withBasePath(
+            `/api/seerr/search?query=${encodeURIComponent(query)}&jellyfin_url=${encodeURIComponent(getServerUrl() || '')}`
+        )
     );
     if (!response.ok) {
         throw new Error(`API request failed: ${response.statusText}`);

--- a/packages/core/src/api/seerr/status.ts
+++ b/packages/core/src/api/seerr/status.ts
@@ -1,9 +1,10 @@
+import { withBasePath } from '../../utils/basePath';
 import { getServerUrl } from '../../utils/localstorageCredentials';
 
 export async function getSeerrLoginStatus(): Promise<boolean> {
     try {
         const response = await fetch(
-            '/api/seerr/status?jellyfin_url=' + encodeURIComponent(getServerUrl() || ''),
+            withBasePath('/api/seerr/status?jellyfin_url=' + encodeURIComponent(getServerUrl() || '')),
             { credentials: 'include' }
         );
         if (!response.ok) {

--- a/packages/core/src/api/stats.ts
+++ b/packages/core/src/api/stats.ts
@@ -1,3 +1,5 @@
+import { withBasePath } from '../utils/basePath';
+
 export type StatsConsent = 'granted' | 'denied' | 'unknown';
 
 const numberToStatsConsent = (value: number): StatsConsent => {
@@ -14,7 +16,7 @@ const numberToStatsConsent = (value: number): StatsConsent => {
 };
 
 export const getStatsConsent = async (): Promise<StatsConsent> => {
-    const res = await fetch('/api/stats-consent');
+    const res = await fetch(withBasePath('/api/stats-consent'));
     if (!res.ok) {
         throw new Error('Failed to fetch stats consent');
     }
@@ -23,7 +25,7 @@ export const getStatsConsent = async (): Promise<StatsConsent> => {
 };
 
 export const setStatsConsent = async (consent: boolean): Promise<void> => {
-    const res = await fetch('/api/stats-consent?consent=' + consent, {
+    const res = await fetch(withBasePath('/api/stats-consent?consent=' + consent), {
         method: 'POST',
     });
     if (!res.ok) {

--- a/packages/core/src/api/themes.ts
+++ b/packages/core/src/api/themes.ts
@@ -1,3 +1,4 @@
+import { withBasePath } from '../utils/basePath';
 import { getServerUrl } from '../utils/localstorageCredentials';
 import { getAuthorizationHeader } from './getApi';
 
@@ -27,7 +28,7 @@ export interface Colors {
 
 export const fetchThemes = async (): Promise<ThemeSummary[]> => {
     const response = await fetch(
-        '/api/themes?jellyfin_url=' + encodeURIComponent(getServerUrl() || '')
+        withBasePath('/api/themes?jellyfin_url=' + encodeURIComponent(getServerUrl() || ''))
     );
     if (!response.ok) {
         throw new Error('Failed to fetch themes');
@@ -37,7 +38,7 @@ export const fetchThemes = async (): Promise<ThemeSummary[]> => {
 
 export const fetchThemeById = async (id: string): Promise<Theme> => {
     const response = await fetch(
-        `/api/themes/${id}?jellyfin_url=` + encodeURIComponent(getServerUrl() || '')
+        withBasePath(`/api/themes/${id}?jellyfin_url=` + encodeURIComponent(getServerUrl() || ''))
     );
     if (!response.ok) {
         throw new Error(`Failed to fetch theme with id: ${id}`);
@@ -47,7 +48,7 @@ export const fetchThemeById = async (id: string): Promise<Theme> => {
 
 export const createTheme = async (theme: string): Promise<{ id: string }> => {
     const response = await fetch(
-        '/api/themes?jellyfin_url=' + encodeURIComponent(getServerUrl() || ''),
+        withBasePath('/api/themes?jellyfin_url=' + encodeURIComponent(getServerUrl() || '')),
         {
             method: 'POST',
             headers: {
@@ -65,7 +66,7 @@ export const createTheme = async (theme: string): Promise<{ id: string }> => {
 
 export const deleteTheme = async (id: string): Promise<void> => {
     const response = await fetch(
-        `/api/themes/${id}?jellyfin_url=` + encodeURIComponent(getServerUrl() || ''),
+        withBasePath(`/api/themes/${id}?jellyfin_url=` + encodeURIComponent(getServerUrl() || '')),
         {
             method: 'DELETE',
             headers: {
@@ -80,7 +81,7 @@ export const deleteTheme = async (id: string): Promise<void> => {
 
 export const updateTheme = async (id: string, theme: Theme): Promise<void> => {
     const response = await fetch(
-        `/api/themes/${id}?jellyfin_url=` + encodeURIComponent(getServerUrl() || ''),
+        withBasePath(`/api/themes/${id}?jellyfin_url=` + encodeURIComponent(getServerUrl() || '')),
         {
             method: 'PUT',
             headers: {
@@ -97,7 +98,10 @@ export const updateTheme = async (id: string, theme: Theme): Promise<void> => {
 
 export const installThemeFromRepository = async (themeId: string): Promise<void> => {
     const response = await fetch(
-        `/api/themes/${themeId}/install?jellyfin_url=` + encodeURIComponent(getServerUrl() || ''),
+        withBasePath(
+            `/api/themes/${themeId}/install?jellyfin_url=` +
+                encodeURIComponent(getServerUrl() || '')
+        ),
         {
             method: 'POST',
             headers: {

--- a/packages/core/src/hooks/useServerAddress.ts
+++ b/packages/core/src/hooks/useServerAddress.ts
@@ -1,7 +1,8 @@
+import { withBasePath } from '../utils/basePath';
 import { useQuery } from '@tanstack/react-query';
 
 const fetchServerAddress = async (): Promise<string> => {
-    const response = await fetch('/api/server-address');
+    const response = await fetch(withBasePath('/api/server-address'));
     if (!response.ok) return '';
     const data: { serverAddress?: string } = await response.json();
     return data.serverAddress || '';

--- a/packages/core/src/hooks/useStudiosApi.ts
+++ b/packages/core/src/hooks/useStudiosApi.ts
@@ -1,4 +1,5 @@
 import { getApi } from '../api/getApi';
+import { withBasePath } from '../utils/basePath';
 import { getAccessToken, getServerUrl } from '../utils/localstorageCredentials';
 import { getItemsApi } from '@jellyfin/sdk/lib/utils/api/items-api';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
@@ -87,7 +88,7 @@ const BACKEND_AVAILABLE_QUERY_KEY = ['studios', 'backend-available'];
 
 async function checkStudiosBackendAvailable(): Promise<boolean> {
     try {
-        const response = await fetch('/api/studios/health');
+        const response = await fetch(withBasePath('/api/studios/health'));
         if (!response.ok) return false;
         const data = (await response.json()) as { ok?: boolean };
         return data.ok === true;
@@ -124,7 +125,7 @@ async function fetchStudiosFromBackend({
     });
     if (search) params.set('search', search);
 
-    const response = await fetch(`/api/studios?${params.toString()}`, {
+    const response = await fetch(withBasePath(`/api/studios?${params.toString()}`), {
         headers: {
             Authorization: token,
         },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -119,3 +119,5 @@ export * from './utils/continueWatchingLines';
 export * from './utils/timeConversion';
 export * from './utils/tmdbUrls';
 export * from './utils/randomUUID';
+export * from './utils/basePath';
+

--- a/packages/core/src/utils/authErrorHandler.ts
+++ b/packages/core/src/utils/authErrorHandler.ts
@@ -1,6 +1,7 @@
 import { logoutFromSeerr } from '../api/seerr/logout';
 import { clearDeviceId } from './deviceId';
 import { clearCredentials } from './localstorageCredentials';
+import { withBasePath } from './basePath';
 
 export function isAuthError(error: unknown): boolean {
     if (error && typeof error === 'object' && 'status' in error) {
@@ -11,7 +12,7 @@ export function isAuthError(error: unknown): boolean {
 }
 
 let onAuthRedirect: () => void = () => {
-    window.location.href = '/login';
+    window.location.href = withBasePath('/login');
 };
 
 export function setAuthRedirectHandler(handler: () => void) {

--- a/packages/core/src/utils/basePath.ts
+++ b/packages/core/src/utils/basePath.ts
@@ -1,0 +1,17 @@
+/*
+ * Public base path the app is served under, derived from Vite's `base` option.
+ *
+ * Normalised to either '' (served at the domain root) or '/segment' with no
+ * trailing slash, so it can be concatenated directly with an absolute path.
+ */
+const rawBase = import.meta.env.BASE_URL ?? '/';
+
+export const BASE_PATH =
+    rawBase === '/' || rawBase === './' || rawBase === '.'
+        ? ''
+        : rawBase.replace(/\/+$/, '');
+
+/** Prefixes an absolute app path with the deployment base path. */
+export function withBasePath(path: string): string {
+    return BASE_PATH + path;
+}

--- a/packages/core/src/utils/jellyfinUrls.ts
+++ b/packages/core/src/utils/jellyfinUrls.ts
@@ -1,3 +1,4 @@
+import { withBasePath } from './basePath';
 import { getAccessToken, getServerUrl } from './localstorageCredentials';
 import { getSupportedVideoCodecs } from './videoCodecDetection';
 import type { PlayMethod } from '../hooks/usePlaybackInfo';
@@ -437,5 +438,5 @@ export function getBackendStudioImageUrl(
     monoColor2: string
 ) {
     const params = new URLSearchParams({ mono: 'true', color: monoColor, color2: monoColor2 });
-    return `/api/studios/${encodeURIComponent(studioName)}/logo?${params.toString()}`;
+    return withBasePath(`/api/studios/${encodeURIComponent(studioName)}/logo?${params.toString()}`);
 }


### PR DESCRIPTION
# Serve the app under a configurable base path (`/pelagica`)

## Why

Lets the whole container be published under a sub-path on the **same host as Jellyfin** (e.g. `https://media.example.com/pelagica`) instead of needing its own hostname or port. The reverse proxy only has to route `/pelagica/*` to this container — the API moves under the prefix too, so nothing else needs forwarding.

## How it works

The base path is a **build-time** constant, resolved once and baked into the image. No runtime substitution, no new environment variable at container start — what gets tested is byte-for-byte what ships.

```
docker build --build-arg BASE_PATH=/pelagica
  ├─ frontend  ARG → env → vite.config.ts `base` → import.meta.env.BASE_URL
  ├─ assets    dist copied to /usr/share/nginx/html/pelagica
  └─ nginx     sed replaces __BASE_PATH__ in nginx.conf + manifest.webmanifest
```

Because the path is compiled into the JS bundle, a base-path deployment needs a **separate image** — hence the new tag.

### Frontend

- New helper `packages/core/src/utils/basePath.ts` exports `BASE_PATH` and `withBasePath()`, derived from `import.meta.env.BASE_URL`.
- 22 API call sites across 14 `packages/core` files and 2 `frontend` files now route through `withBasePath()`.
- `BrowserRouter` gets a `basename`, so client-side routes and deep-link refreshes resolve.
- Vite `base` and the dev-server proxy key are both derived from `BASE_PATH`.

### nginx / Docker

- `nginx.conf` uses `__BASE_PATH__` placeholders substituted at build time. **One file serves both variants** — empty substitution yields exactly today's config, so the two can't drift apart.
- `proxy_pass` gained a trailing `/api/` so nginx *replaces* the matched prefix: `/pelagica/api/themes` reaches the Go backend as `/api/themes`. **No backend changes.**
- `dist` is copied into a subdirectory rather than using nginx `alias`, avoiding the known `alias` + `try_files` breakage.
- The stock nginx `index.html` is removed before the frontend copy, so a base-path image serves nothing at `/`.

### CI

A `variant` matrix dimension builds both images:

| variant | manifest tags | `BASE_PATH` |
|---|---|---|
| default | `:<version>`, `:latest` | *(empty)* |
| basepath | `:<version>-basepath`, `:latest-basepath` | `/pelagica` |

Default-variant tags are **byte-identical to today's**, including per-arch intermediates. Digest artifacts are variant-scoped so the two merge jobs can't produce a mixed manifest.

## Backwards compatibility

Nothing changes when `BASE_PATH` is unset — verified against a running container, not just by inspection.

`withBasePath()` normalises `'/'`, `'./'` and `'.'` to `''`. The `'./'` case matters: the Tizen and webOS builds set `base: './'`, and without that guard they'd produce broken `.//api/...` URLs.

## Verification

Both images built and run side by side, no volumes:

| check | basepath image | root image |
|---|---|---|
| `/` | 403, no nginx page | 200, the app |
| deep link | `/pelagica/library` 200 | `/library` 200 |
| API | `/pelagica/api/server-address` 200 | `/api/server-address` 200 |
| manifest `start_url` | `/pelagica/` | `/` |
| asset prefix | `/pelagica/assets/` | `/assets/` |

`tsc -b` passes inside the Docker build. Vite was confirmed to rewrite every asset reference in `index.html` (favicons, manifest link, module script, all modulepreloads).

The workflow is validated by simulating the matrix expansion against the parsed YAML — tag strings and job wiring are correct, but only a real release exercises the 4-job push.

## Decisions for the maintainer

**Tag naming is yours to change.** `-basepath` lives entirely in the `suffix` fields of the two matrix blocks; nothing else depends on it. Alternatives if it reads badly beside the existing `latest-<arch>` intermediates: `-subpath`, `-pelagica`, or a dedicated namespace.

**This doubles the release matrix**, 2 builds → 4, arm64 included. If that cost isn't worth paying every release, the variant could be gated behind a `workflow_dispatch` input or split into a manually-triggered workflow.

**The variant list is duplicated** across the `build` and `merge` jobs — GitHub Actions has no YAML anchors, so a third variant would mean editing both.

**The path value `/pelagica` is hardcoded**, not configurable, deliberately: the image stays immutable with no runtime knob to misconfigure. Supporting arbitrary paths would mean reintroducing runtime substitution.
